### PR TITLE
chore: improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check: prereqs
 # --------------------------
 # Push all images
 # --------------------------
-push: all $(PUSH_TARGETS)
+push: prereqs $(PUSH_TARGETS)
 	@echo -e "$(GREEN)======================================================$(NC)"
 	@echo -e "$(GREEN)Push successful for all projects: $(DIRS)$(NC)"
 	@echo -e "$(GREEN)======================================================$(NC)"
@@ -56,7 +56,7 @@ push: all $(PUSH_TARGETS)
 # Generic per-project push
 # Usage: make push-<project>
 # --------------------------
-$(PUSH_TARGETS): push-%: prereqs %
+$(PUSH_TARGETS): push-%: prereqs
 	@echo -e "$(BLUE)Performing bake --push for $*...$(NC)"
 ifeq ($(DRY_RUN),true)
 	@echo -e "$(GREEN)[DRY RUN] docker buildx bake -f $*/metadata.hcl -f docker-bake.hcl --push$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ SHELL := $(shell which bash 2>/dev/null || echo /bin/sh)
 FILES := $(shell find . -type f -name metadata.hcl)
 DIRS  := $(patsubst %/,%,$(patsubst ./%,%,$(dir $(FILES))))
 
+ifeq ($(DIRS),)
+$(error No subdirectories with metadata.hcl files found)
+endif
+
 # Create push targets for each directory
 PUSH_TARGETS := $(addprefix push-,$(DIRS))
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ prereqs:
 check: prereqs
 	@echo -e "$(BLUE)Performing bake --check for all projects...$(NC)"
 	@$(foreach dir,$(DIRS), \
-		echo -e "$(BLUE)[CHECK] $dir$(NC)"; \
+		echo -e "$(BLUE)[CHECK] $(dir) $(NC)"; \
 		docker buildx bake -f $(dir)/metadata.hcl -f docker-bake.hcl --check; \
 	)
 


### PR DESCRIPTION
When the shell used for `sh` is `dash`, which is common on Debian and its derivatives, the output of the Makefile is incorrect. This patch resolves the issue by using `bash` as the shell when it's available.

Additionally, I refactored the `push` target to reuse the code that executes the push command for a specific directory.

Lastly, the default action when you run `make` without any arguments is now to build all the extensions.