### PR TITLE
chore: all the GitHub actions update into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,21 @@
       "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",
       "datasourceTemplate": "deb"
     }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "pinDigest",
+        "major",
+        "minor",
+        "patch"
+      ],
+      "groupName": "all github action",
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
We create only one PR for all the GitHub actions updates.

Closes #32 