### PR TITLE
chore(github): implement 'New Extension Proposal' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
   - name: Slack chat
     url: https://github.com/cloudnative-pg/cloudnative-pg?tab=readme-ov-file#communications
     about: Please join the slack channel and interact with our community

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+blank_issues_enabled: false
+  - name: Slack chat
+    url: https://github.com/cloudnative-pg/cloudnative-pg?tab=readme-ov-file#communications
+    about: Please join the slack channel and interact with our community

--- a/.github/ISSUE_TEMPLATE/extension.yaml
+++ b/.github/ISSUE_TEMPLATE/extension.yaml
@@ -7,10 +7,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for proposing a new extension for the PostgreSQL Extensions Containers project! 
-        
+        Thanks for proposing a new extension for the PostgreSQL Extensions Containers project!
+
         The submission process requires the proposer to commit to becoming the **Component Owner** and taking on the long-term maintenance of the extension image. Please review the [governance document for the submission process](https://github.com/cloudnative-pg/postgres-extensions-containers?tab=readme-ov-file#submission-process).
-  
+
   - type: checkboxes
     id: search
     attributes:
@@ -28,7 +28,7 @@ body:
       placeholder: ex. pgvector
     validations:
       required: true
-      
+
   - type: input
     id: project-url
     attributes:
@@ -55,7 +55,7 @@ body:
       placeholder: ex. The pgvector extension provides vector similarity search capabilities for PostgreSQL.
     validations:
       required: true
-      
+
   - type: input
     id: license-url
     attributes:
@@ -64,7 +64,7 @@ body:
       placeholder: ex. https://github.com/pgvector/pgvector/blob/master/LICENSE
     validations:
       required: true
-      
+
   - type: checkboxes
     id: license-check
     attributes:
@@ -73,7 +73,16 @@ body:
       options:
         - label: The extension's license (linked above) complies with the list of allowed licenses.
           required: true
-          
+
+  - type: textarea
+    id: dependent-extensions
+    attributes:
+      label: Known Dependent Extensions
+      description: List any other PostgreSQL extensions that MUST be installed before or alongside this extension (e.g., if this extension requires 'plpgsql' or 'postgis' to be present). If none, please state "None".
+      placeholder: ex. postgis
+    validations:
+      required: true
+
   - type: checkboxes
     id: maintenance-commitment
     attributes:
@@ -82,16 +91,16 @@ body:
       options:
         - label: I/My organization commit to becoming the Component Owner and maintaining the extension image in the future.
           required: true
-          
+
   - type: textarea
     id: additional-notes
     attributes:
       label: Additional Notes (Optional)
-      description: Any other relevant information, required dependencies, or context that might be useful for packaging.
-      placeholder: ex. This extension requires the 'openssl' library to be installed.
+      description: Any other relevant information, required dependencies (like OS packages), or context that might be useful for packaging.
+      placeholder: ex. This extension requires the 'openssl' library (OS package) to be installed.
     validations:
       required: false
-      
+
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/extension.yaml
+++ b/.github/ISSUE_TEMPLATE/extension.yaml
@@ -1,0 +1,102 @@
+name: New Extension Proposal
+description: Propose a new PostgreSQL extension to be included in the containers and commit to its maintenance.
+title: "[New Extension]: "
+labels: ["triage", "new-extension"]
+projects: ["cloudnative-pg/postgres-extensions-containers"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new extension for the PostgreSQL Extensions Containers project! 
+        
+        The submission process requires the proposer to commit to becoming the **Component Owner** and taking on the long-term maintenance of the extension image. Please review the [governance document for the submission process](https://github.com/cloudnative-pg/postgres-extensions-containers?tab=readme-ov-file#submission-process).
+  
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Is there an existing issue for this extension request?
+      description: Before you submit a request, please **search existing issues** to ensure this extension hasn't already been proposed.
+      options:
+        - label: I have searched for an existing issue, and could not find a duplicate request.
+          required: true
+
+  - type: input
+    id: extension-name
+    attributes:
+      label: Extension Name
+      description: What is the official name of the PostgreSQL extension?
+      placeholder: ex. pgvector
+    validations:
+      required: true
+      
+  - type: input
+    id: project-url
+    attributes:
+      label: Project Repository URL
+      description: The URL of the main source code repository (e.g., GitHub, GitLab).
+      placeholder: ex. https://github.com/pgvector/pgvector
+    validations:
+      required: true
+
+  - type: input
+    id: website-url
+    attributes:
+      label: Extension Website URL (Optional)
+      description: The URL of the official website or main documentation page.
+      placeholder: ex. https://pgvector.io/
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Short Description
+      description: A brief description of the extension and its primary use case.
+      placeholder: ex. The pgvector extension provides vector similarity search capabilities for PostgreSQL.
+    validations:
+      required: true
+      
+  - type: input
+    id: license-url
+    attributes:
+      label: Main LICENSE Link
+      description: A direct link to the main license file in the repository (e.g., a link to the raw LICENSE file).
+      placeholder: ex. https://github.com/pgvector/pgvector/blob/master/LICENSE
+    validations:
+      required: true
+      
+  - type: checkboxes
+    id: license-check
+    attributes:
+      label: License Compliance
+      description: Please confirm the license of the extension complies with the **allowed licenses** for this project.
+      options:
+        - label: The extension's license (linked above) complies with the list of allowed licenses.
+          required: true
+          
+  - type: checkboxes
+    id: maintenance-commitment
+    attributes:
+      label: Component Owner and Maintenance Commitment
+      description: By checking this box, you confirm your commitment to the long-term maintenance of the extension image. This includes providing updates for new upstream versions, responding to security issues, and ensuring compatibility with new PostgreSQL/OS versions.
+      options:
+        - label: I/My organization commit to becoming the Component Owner and maintaining the extension image in the future.
+          required: true
+          
+  - type: textarea
+    id: additional-notes
+    attributes:
+      label: Additional Notes (Optional)
+      description: Any other relevant information, required dependencies, or context that might be useful for packaging.
+      placeholder: ex. This extension requires the 'openssl' library to be installed.
+    validations:
+      required: false
+      
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/cloudnative-pg/governance/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/extension.yaml
+++ b/.github/ISSUE_TEMPLATE/extension.yaml
@@ -101,6 +101,15 @@ body:
     validations:
       required: false
 
+- type: input
+    id: github-handles
+    attributes:
+      label: GitHub Handles of Component Owners
+      description: List the GitHub handles (e.g., `@user1`, `@org/team`) that will be responsible for maintaining the extension and should be added to the `CODEOWNERS` file.
+      placeholder: ex. @user1
+    validations:
+      required: true
+
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/extension.yaml
+++ b/.github/ISSUE_TEMPLATE/extension.yaml
@@ -101,7 +101,7 @@ body:
     validations:
       required: false
 
-- type: input
+  - type: input
     id: github-handles
     attributes:
       label: GitHub Handles of Component Owners


### PR DESCRIPTION
Introduces a required issue template for requesting the inclusion of new PostgreSQL extensions into the containers project.

This template ensures all necessary information is provided upfront, specifically requiring:

- Confirmation that no duplicate request exists.
- Project metadata (name, URLs, description, license).
- Mandatory confirmation that the license is compliant.
- Identification of known dependent extensions.
- Explicit commitment from the proposer to act as the Component Owner and maintain the extension image in compliance with project governance.

Closes #41 
