### PR TITLE
feat: automate generation of chainsaw testing values

### DIFF
--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -130,12 +130,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
-        with:
-          cache: false
-          go-version: 'stable'
-
       - name: Create kind cluster
         uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
         with:
@@ -155,24 +149,16 @@ jobs:
           curl -sSfL "$operator_manifest" | kubectl apply --server-side -f -
           kubectl wait --for=condition=Available --timeout=2m -n cnpg-system deployments cnpg-controller-manager
 
-      - name: Generate Chainsaw runtime values
+      - name: Generate Chainsaw testing values
+        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644 # v8.2.0
         env:
-          EXT_NAME: ${{ inputs.extension_name }}
-          EXT_IMAGE: ${{ matrix.image }}
-        run: |
-          # Get the PG base image
-          export PG_IMAGE=$(skopeo inspect "docker://$EXT_IMAGE" -f '{{ json .Labels }}' | jq -r '."io.cloudnativepg.image.base.name"')
-
-          go install github.com/tmccombs/hcl2json@v0.6.8
-          go install github.com/mikefarah/yq/v4@v4
-
-          # Convert metadata.hcl to YAML and merge it with runtime values to generate a valid Chainsaw values.yaml
-          yq eval -P '
-            .metadata.extension_image = strenv(EXT_IMAGE) |
-            .metadata.pg_image = strenv(PG_IMAGE) |
-            .metadata
-          ' <(hcl2json "$EXT_NAME/metadata.hcl") > "$EXT_NAME/values.yaml"
-          cat "$EXT_NAME/values.yaml"
+          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+          DAGGER_VERSION: 0.19.7
+        with:
+          version: ${{ env.DAGGER_VERSION }}
+          verb: call
+          module: ./dagger/maintenance/
+          args: generate-testing-values --target ${{ inputs.extension_name }} --extension-image ${{ matrix.image }}
 
       - name: Install Chainsaw
         uses: kyverno/action-install-chainsaw@06560d18422209e9c1e08e931d477d04bf2674c1 # v0.2.14

--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -158,7 +158,7 @@ jobs:
           version: ${{ env.DAGGER_VERSION }}
           verb: call
           module: ./dagger/maintenance/
-          args: generate-testing-values --target ${{ inputs.extension_name }} --extension-image ${{ matrix.image }}
+          args: generate-testing-values --target ${{ inputs.extension_name }} --extension-image ${{ matrix.image }} export --path=${{ inputs.extension_name }}/values.yaml
 
       - name: Install Chainsaw
         uses: kyverno/action-install-chainsaw@06560d18422209e9c1e08e931d477d04bf2674c1 # v0.2.14

--- a/dagger/maintenance/go.mod
+++ b/dagger/maintenance/go.mod
@@ -4,6 +4,7 @@ go 1.25.3
 
 require (
 	github.com/docker/buildx v0.30.1
+	github.com/google/go-containerregistry v0.20.6
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/vektah/gqlparser/v2 v2.5.30
 	go.opentelemetry.io/otel v1.38.0
@@ -42,10 +43,12 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.2 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.17.0 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v28.5.1+incompatible // indirect
+	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v28.5.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/docker/go v1.5.1-1 // indirect
@@ -71,6 +74,7 @@ require (
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/moby/buildkit v0.26.1 // indirect
@@ -101,6 +105,7 @@ require (
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect
+	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/zclconf/go-cty v1.17.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -119,7 +124,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.14.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
 	go.opentelemetry.io/proto/otlp v1.8.0
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.42.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.44.0 // indirect

--- a/dagger/maintenance/go.sum
+++ b/dagger/maintenance/go.sum
@@ -80,7 +80,6 @@ github.com/containerd/platforms v1.0.0-rc.2 h1:0SPgaNZPVWGEi4grZdV8VRYQn78y+nm6a
 github.com/containerd/platforms v1.0.0-rc.2/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLVRzJGXfNuWCZCllLA4=
 github.com/containerd/plugin v1.0.0 h1:c8Kf1TNl6+e2TtMHZt+39yAPDbouRH9WAToRjex483Y=
 github.com/containerd/plugin v1.0.0/go.mod h1:hQfJe5nmWfImiqT1q8Si3jLv3ynMUIBB47bQ+KexvO8=
-github.com/containerd/stargz-snapshotter v0.17.0 h1:djNS4KU8ztFhLdEDZ1bsfzOiYuVHT6TgSU5qwRk+cNc=
 github.com/containerd/stargz-snapshotter/estargz v0.17.0 h1:+TyQIsR/zSFI1Rm31EQBwpAA1ovYgIKHy7kctL3sLcE=
 github.com/containerd/stargz-snapshotter/estargz v0.17.0/go.mod h1:s06tWAiJcXQo9/8AReBCIo/QxcXFZ2n4qfsRnpl71SM=
 github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRqQ=
@@ -138,6 +137,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB31qAwjAohdSTU=
+github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -170,6 +171,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strconv"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	containerregistryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -14,35 +17,45 @@ const (
 	DefaultDistribution = "trixie"
 )
 
-// getImageLabels returns the OCI labels given an image ref.
-func getImageLabels(imageRef string) (map[string]string, error) {
+// getImageAnnotations returns the OCI annotations given an image ref.
+func getImageAnnotations(imageRef string) (map[string]string, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return nil, err
 	}
 
-	desc, err := remote.Get(ref)
+	head, err := remote.Get(ref)
 	if err != nil {
 		return nil, err
 	}
 
-	img, err := desc.Image()
-	if err != nil {
-		return nil, err
+	switch head.MediaType {
+	case ocispecv1.MediaTypeImageIndex:
+		indexManifest, err := containerregistryv1.ParseIndexManifest(bytes.NewReader(head.Manifest))
+		if err != nil {
+			return nil, err
+		}
+		return indexManifest.Annotations, nil
+	case ocispecv1.MediaTypeImageManifest:
+		manifest, err := containerregistryv1.ParseManifest(bytes.NewReader(head.Manifest))
+		if err != nil {
+			return nil, err
+		}
+		return manifest.Annotations, nil
 	}
 
-	cfg, err := img.ConfigFile()
-	if err != nil {
-		return nil, err
-	}
-
-	return cfg.Config.Labels, nil
+	return nil, fmt.Errorf("unsupported media type: %s", head.MediaType)
 }
 
 // getDefaultExtensionImage returns the default extension image for a given extension,
 // resolved from the metadata.
 func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {
 	packageVersion := metadata.Versions[DefaultDistribution][strconv.Itoa(DefaultPgMajor)]
+	if packageVersion == "" {
+		return "", fmt.Errorf("no package version found for distribution %q and version %d",
+			DefaultDistribution, DefaultPgMajor)
+	}
+
 	re := regexp.MustCompile(`^(\d+(?:\.\d+)+)`)
 	matches := re.FindStringSubmatch(packageVersion)
 	if len(matches) < 2 {

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+const (
+	DefaultPgMajor      = 18
+	DefaultDistribution = "trixie"
+)
+
+// getImageLabels returns the OCI labels given an image ref.
+func getImageLabels(imageRef string) (map[string]string, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	desc, err := remote.Get(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.Config.Labels, nil
+}
+
+// getDefaultExtensionImage returns the default extension image for a given extension,
+// resolved from the metadata.
+func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {
+	packageVersion := metadata.Versions[DefaultDistribution][strconv.Itoa(DefaultPgMajor)]
+	re := regexp.MustCompile(`^(\d+(?:\.\d+)+)`)
+	matches := re.FindStringSubmatch(packageVersion)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("cannot extract extension version from %q", packageVersion)
+	}
+	version := matches[1]
+	image := fmt.Sprintf("ghcr.io/cloudnative-pg/%s:%s-%d-%s",
+		metadata.ImageName, version, DefaultPgMajor, DefaultDistribution)
+
+	return image, nil
+}

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"maps"
 	"path"
 	"slices"
@@ -122,6 +123,20 @@ func (m *Maintenance) GenerateTestingValues(
 		return nil, err
 	}
 
+	pgImage := annotations["io.cloudnativepg.image.base.name"]
+	if pgImage == "" {
+		return nil, fmt.Errorf(
+			"extension image %s doesn't have an 'io.cloudnativepg.image.base.name' annotation",
+			targetExtensionImage)
+	}
+
+	version := annotations["org.opencontainers.image.version"]
+	if version == "" {
+		return nil, fmt.Errorf(
+			"extension image %s doesn't have an 'org.opencontainers.image.version' annotation",
+			targetExtensionImage)
+	}
+
 	// Build values.yaml content
 	values := map[string]any{
 		"name":                     metadata.Name,
@@ -132,8 +147,8 @@ func (m *Maintenance) GenerateTestingValues(
 		"dynamic_library_path":     metadata.DynamicLibraryPath,
 		"ld_library_path":          metadata.LdLibraryPath,
 		"extension_image":          targetExtensionImage,
-		"pg_image":                 annotations["io.cloudnativepg.image.base.name"],
-		"version":                  annotations["org.opencontainers.image.version"],
+		"pg_image":                 pgImage,
+		"version":                  version,
 	}
 	valuesYaml, err := yaml.Marshal(values)
 	if err != nil {

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"slices"
 
+	"go.yaml.in/yaml/v3"
+
 	"dagger/maintenance/internal/dagger"
 )
 
@@ -91,4 +93,54 @@ func (m *Maintenance) GetOSLibsTargets(
 	}
 
 	return string(jsonTargets), nil
+}
+
+// Generates Chainsaw's testing external values in YAML format
+func (m *Maintenance) GenerateTestingValues(
+	ctx context.Context,
+	// Path to the target extension directory
+	target *dagger.Directory,
+	// URL reference to the extension image to test [REPOSITORY[:TAG]]
+	// +optional
+	extensionImage string,
+) (*dagger.File, error) {
+	metadata, err := parseExtensionMetadata(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	targetExtensionImage := extensionImage
+	if targetExtensionImage == "" {
+		targetExtensionImage, err = getDefaultExtensionImage(metadata)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	labels, err := getImageLabels(targetExtensionImage)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build values.yaml content
+	values := map[string]any{
+		"name":                     metadata.Name,
+		"sql_name":                 metadata.SQLName,
+		"image_name":               metadata.ImageName,
+		"shared_preload_libraries": metadata.SharedPreloadLibraries,
+		"extension_control_path":   metadata.ExtensionControlPath,
+		"dynamic_library_path":     metadata.DynamicLibraryPath,
+		"ld_library_path":          metadata.LdLibraryPath,
+		"extension_image":          targetExtensionImage,
+		"pg_image":                 labels["io.cloudnativepg.image.base.name"],
+		"version":                  labels["org.opencontainers.image.version"],
+	}
+	valuesYaml, err := yaml.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	result := target.WithNewFile("values.yaml", string(valuesYaml))
+
+	return result.File("values.yaml"), nil
 }

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -117,7 +117,7 @@ func (m *Maintenance) GenerateTestingValues(
 		}
 	}
 
-	labels, err := getImageLabels(targetExtensionImage)
+	annotations, err := getImageAnnotations(targetExtensionImage)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +132,8 @@ func (m *Maintenance) GenerateTestingValues(
 		"dynamic_library_path":     metadata.DynamicLibraryPath,
 		"ld_library_path":          metadata.LdLibraryPath,
 		"extension_image":          targetExtensionImage,
-		"pg_image":                 labels["io.cloudnativepg.image.base.name"],
-		"version":                  labels["org.opencontainers.image.version"],
+		"pg_image":                 annotations["io.cloudnativepg.image.base.name"],
+		"version":                  annotations["org.opencontainers.image.version"],
 	}
 	valuesYaml, err := yaml.Marshal(values)
 	if err != nil {

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -17,10 +17,19 @@ type buildMatrix struct {
 	MajorVersions []string
 }
 
+type versionMap map[string]map[string]string
+
 type extensionMetadata struct {
-	Name             string   `hcl:"name" cty:"name"`
-	AutoUpdateOsLibs bool     `hcl:"auto_update_os_libs" cty:"auto_update_os_libs"`
-	Remain           hcl.Body `hcl:",remain"`
+	Name                   string     `hcl:"name" cty:"name"`
+	SQLName                string     `hcl:"sql_name" cty:"sql_name"`
+	ImageName              string     `hcl:"image_name" cty:"image_name"`
+	SharedPreloadLibraries []string   `hcl:"shared_preload_libraries" cty:"shared_preload_libraries"`
+	ExtensionControlPath   []string   `hcl:"extension_control_path" cty:"extension_control_path"`
+	DynamicLibraryPath     []string   `hcl:"dynamic_library_path" cty:"dynamic_library_path"`
+	LdLibraryPath          []string   `hcl:"ld_library_path" cty:"ld_library_path"`
+	AutoUpdateOsLibs       bool       `hcl:"auto_update_os_libs" cty:"auto_update_os_libs"`
+	Versions               versionMap `hcl:"versions" cty:"versions"`
+	Remain                 hcl.Body   `hcl:",remain"`
 }
 
 const (


### PR DESCRIPTION
Implement a new dagger command to automate the creation of Chainsaw's testing `values.yaml` for a target extension.

Closes #47 