### PR TITLE
chore: Add "update readme" Dagger command

### DIFF
--- a/dagger/maintenance/update_readme.go
+++ b/dagger/maintenance/update_readme.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"dagger/maintenance/internal/dagger"
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+)
+
+const readmeFilename = "README.md"
+
+func updateReadme(ctx context.Context, target *dagger.Directory) (*dagger.File, error) {
+	metadata, err := parseExtensionMetadata(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	extImage, extImageErr := getDefaultExtensionImage(metadata)
+	if extImageErr != nil {
+		return nil, extImageErr
+	}
+	readmeFile := target.File(readmeFilename)
+	if readmeFile == nil {
+		return nil, errors.New("README file not found")
+	}
+
+	readmeContent, contentErr := readmeFile.Contents(ctx)
+	if contentErr != nil {
+		return nil, contentErr
+	}
+	searchPattern := fmt.Sprintf(
+		`(ghcr\.io\/cloudnative-pg\/%s:)(\d+(?:\.\d+)+)-%d-%s`,
+		metadata.Name,
+		DefaultPgMajor,
+		DefaultDistribution,
+	)
+
+	re := regexp.MustCompile(searchPattern)
+
+	newContent := re.ReplaceAllString(readmeContent, extImage)
+
+	out := target.WithNewFile(readmeFilename, newContent)
+
+	return out.File(readmeFilename), nil
+
+}
+
+func extensionsWithReadme(
+	ctx context.Context,
+	source *dagger.Directory,
+) (map[string]string, error) {
+	dirs, err := extensionsDirectories(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+
+	extensions := make(map[string]string)
+	for _, dir := range dirs {
+		metadata, err := parseExtensionMetadata(ctx, dir)
+		if err != nil {
+			return nil, err
+		}
+		dirName, err := dir.Name(ctx)
+		if err != nil {
+			return nil, err
+		}
+		exists, existsErr := dir.Exists(ctx, readmeFilename)
+		if existsErr == nil && exists {
+			extensions[path.Dir(dirName)] = metadata.Name
+		}
+	}
+
+	return extensions, nil
+}


### PR DESCRIPTION
Based on #47 (Needs to be rebased after merge)


## Usage
```
dagger \
--progress plain \
call \
-m ./dagger/maintenance/ \
update-readme
```
```
Updates the container image in the readme for the specified extension(s)

USAGE
  dagger call update-readme [arguments] <function>

ARGUMENTS
      --source Directory   The source directory containing the extension folders. Defaults to the current directory
      --target string      The target extension to update the README. Defaults to "all". (default "all")

```

## Update all readme

```
dagger \
--progress plain \
call \
-m ./dagger/maintenance/ \
update-readme  export --path=.
```

## Update a single readme

```
EXT_NAME=postgis

dagger \
--progress plain \
call \
-m ./dagger/maintenance/ \
update-readme --target $EXT_NAME export --path=.
```

Solve #11 