### PR TITLE
chore: Add update readme dagger command

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,0 +1,83 @@
+name: Check Readme updates
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "**/metadata.hcl"
+
+jobs:
+  detect-changes:
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_changes: ${{ steps.set-matrix.outputs.has_changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Get changed metadata files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: "**/metadata.hcl"
+
+      - name: Create Matrix Output
+        id: set-matrix
+        run: |
+          FOLDERS=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n' | xargs -I {} dirname {} | sort -u | jq -R -s -c 'split("\n") | del(.[] | select(. == "" or . == "."))')
+          
+          echo "Folders detected: $FOLDERS"
+          
+          if [ "$FOLDERS" == "[]" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=$FOLDERS" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+  process-metadata:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        extension: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Update Readme for ${{ matrix.extension }}
+        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644 # v8.2.0
+        env:
+          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+          DAGGER_VERSION: 0.19.8
+        with:
+          version: ${{ env.DAGGER_VERSION }}
+          verb: call
+          module: ./dagger/maintenance/
+          args: update-readme --target ${{ matrix.extension }} export --path=.
+
+      - name: Diff
+        run: |
+          git status
+          git diff
+
+      - uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: 'docs: Update ${{ matrix.extension }} README.md'
+          file_pattern: '*/README.md'
+          # See https://git-scm.com/docs/git-commit#_options
+          commit_options: '--signoff'

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -6,30 +6,38 @@ on:
     paths:
       - "**/metadata.hcl"
 
+defaults:
+  run:
+    shell: 'bash -Eeuo pipefail -x {0}'
+
+permissions: {}
+
 jobs:
   detect-changes:
     if: github.event.pull_request.user.login == 'renovate[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_changes: ${{ steps.set-matrix.outputs.has_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Get changed metadata files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: "**/metadata.hcl"
 
       - name: Create Matrix Output
         id: set-matrix
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          FOLDERS=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n' | xargs -I {} dirname {} | sort -u | jq -R -s -c 'split("\n") | del(.[] | select(. == "" or . == "."))')
+          FOLDERS=$(echo "$ALL_CHANGED_FILES" | tr ' ' '\n' | xargs -I {} dirname {} | sort -u | jq -R -s -c 'split("\n") | del(.[] | select(. == "" or . == "."))')
           
           echo "Folders detected: $FOLDERS"
           
@@ -43,10 +51,10 @@ jobs:
   process-metadata:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
+      # added or changed files to the pull request.
       contents: write
     strategy:
       fail-fast: false
@@ -54,7 +62,7 @@ jobs:
         extension: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -75,7 +83,7 @@ jobs:
           git status
           git diff
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'docs: Update ${{ matrix.extension }} README.md'
           file_pattern: '*/README.md'

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -50,6 +50,19 @@ func getImageAnnotations(imageRef string) (map[string]string, error) {
 // getDefaultExtensionImage returns the default extension image for a given extension,
 // resolved from the metadata.
 func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {
+	version, err := getDefaultExtensionVersion(metadata)
+	if err != nil {
+		return "", err
+	}
+	image := fmt.Sprintf("ghcr.io/cloudnative-pg/%s:%s-%d-%s",
+		metadata.ImageName, version, DefaultPgMajor, DefaultDistribution)
+
+	return image, nil
+}
+
+// getDefaultExtensionVersion returns the default extension version for a given extension,
+// resolved from the metadata.
+func getDefaultExtensionVersion(metadata *extensionMetadata) (string, error) {
 	packageVersion := metadata.Versions[DefaultDistribution][strconv.Itoa(DefaultPgMajor)]
 	if packageVersion == "" {
 		return "", fmt.Errorf("no package version found for distribution %q and version %d",
@@ -62,8 +75,5 @@ func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {
 		return "", fmt.Errorf("cannot extract extension version from %q", packageVersion)
 	}
 	version := matches[1]
-	image := fmt.Sprintf("ghcr.io/cloudnative-pg/%s:%s-%d-%s",
-		metadata.ImageName, version, DefaultPgMajor, DefaultDistribution)
-
-	return image, nil
+	return version, nil
 }

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -21,12 +21,12 @@ type Maintenance struct{}
 // Updates the OS dependencies in the system-libs directory for the specified extension(s)
 func (m *Maintenance) UpdateOSLibs(
 	ctx context.Context,
-// The source directory containing the extension folders. Defaults to the current directory
-// +ignore=["dagger", ".github"]
-// +defaultPath="/"
+	// The source directory containing the extension folders. Defaults to the current directory
+	// +ignore=["dagger", ".github"]
+	// +defaultPath="/"
 	source *dagger.Directory,
-// The target extension to update OS libs for. Defaults to "all".
-// +default="all"
+	// The target extension to update OS libs for. Defaults to "all".
+	// +default="all"
 	target string,
 ) (*dagger.Directory, error) {
 	extDir := source
@@ -89,12 +89,12 @@ func (m *Maintenance) UpdateOSLibs(
 // Updates the container image in the readme for the specified extension(s)
 func (m *Maintenance) UpdateReadme(
 	ctx context.Context,
-// The source directory containing the extension folders. Defaults to the current directory
-// +ignore=["dagger", ".github"]
-// +defaultPath="/"
+	// The source directory containing the extension folders. Defaults to the current directory
+	// +ignore=["dagger", ".github"]
+	// +defaultPath="/"
 	source *dagger.Directory,
-// The target extension to update the README. Defaults to "all".
-// +default="all"
+	// The target extension to update the README. Defaults to "all".
+	// +default="all"
 	target string,
 ) (*dagger.Directory, error) {
 	extDir := source
@@ -127,9 +127,9 @@ func (m *Maintenance) UpdateReadme(
 // Retrieves a list in JSON format of the extensions requiring OS libs updates
 func (m *Maintenance) GetOSLibsTargets(
 	ctx context.Context,
-// The source directory containing the extension folders. Defaults to the current directory
-// +ignore=["dagger", ".github"]
-// +defaultPath="/"
+	// The source directory containing the extension folders. Defaults to the current directory
+	// +ignore=["dagger", ".github"]
+	// +defaultPath="/"
 	source *dagger.Directory,
 ) (string, error) {
 	targetExtensions, err := getExtensions(ctx, source, WithOSLibsFilter())
@@ -147,9 +147,9 @@ func (m *Maintenance) GetOSLibsTargets(
 // Retrieves a list in JSON format of the extensions
 func (m *Maintenance) GetTargets(
 	ctx context.Context,
-// The source directory containing the extension folders. Defaults to the current directory
-// +ignore=["dagger", ".github"]
-// +defaultPath="/"
+	// The source directory containing the extension folders. Defaults to the current directory
+	// +ignore=["dagger", ".github"]
+	// +defaultPath="/"
 	source *dagger.Directory,
 ) (string, error) {
 	targetExtensions, err := getExtensions(ctx, source)
@@ -167,10 +167,10 @@ func (m *Maintenance) GetTargets(
 // Generates Chainsaw's testing external values in YAML format
 func (m *Maintenance) GenerateTestingValues(
 	ctx context.Context,
-// Path to the target extension directory
+	// Path to the target extension directory
 	target *dagger.Directory,
-// URL reference to the extension image to test [REPOSITORY[:TAG]]
-// +optional
+	// URL reference to the extension image to test [REPOSITORY[:TAG]]
+	// +optional
 	extensionImage string,
 ) (*dagger.File, error) {
 	metadata, err := parseExtensionMetadata(ctx, target)

--- a/dagger/maintenance/update_readme.go
+++ b/dagger/maintenance/update_readme.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"dagger/maintenance/internal/dagger"
+)
+
+const readmeFilename = "README.md"
+
+type updateFunc func(metadata *extensionMetadata, content string) string
+
+var updates = []updateFunc{
+	updateExtensionImage,
+	updateExtensionVersion,
+}
+
+func updateReadme(ctx context.Context, target *dagger.Directory) (*dagger.File, error) {
+	metadata, err := parseExtensionMetadata(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	readmeFile := target.File(readmeFilename)
+	if readmeFile == nil {
+		return nil, errors.New("README file not found")
+	}
+
+	readmeContent, contentErr := readmeFile.Contents(ctx)
+	if contentErr != nil {
+		return nil, contentErr
+	}
+
+	for _, upd := range updates {
+		readmeContent = upd(metadata, readmeContent)
+	}
+
+	out := target.WithNewFile(readmeFilename, readmeContent)
+
+	return out.File(readmeFilename), nil
+
+}
+
+func updateExtensionImage(metadata *extensionMetadata, content string) string {
+	extImage, extImageErr := getDefaultExtensionImage(metadata)
+	if extImageErr != nil {
+		return content
+	}
+	searchPattern := fmt.Sprintf(
+		`(ghcr\.io\/cloudnative-pg\/%s:)(\d+(?:\.\d+)+)-%d-%s`,
+		metadata.ImageName,
+		DefaultPgMajor,
+		DefaultDistribution,
+	)
+
+	re := regexp.MustCompile(searchPattern)
+
+	return re.ReplaceAllString(content, extImage)
+}
+
+func updateExtensionVersion(metadata *extensionMetadata, content string) string {
+	extVersion, extVersionErr := getDefaultExtensionVersion(metadata)
+	if extVersionErr != nil {
+		return content
+	}
+
+	pattern := fmt.Sprintf(`(- name:\s+%s)(\s+version:\s+)(['"].*?['"])`, regexp.QuoteMeta(metadata.SQLName))
+	re := regexp.MustCompile(pattern)
+
+	replacement := fmt.Sprintf(`$1$2'%s'`, extVersion)
+
+	return re.ReplaceAllString(content, replacement)
+}

--- a/dagger/maintenance/updatelibs.go
+++ b/dagger/maintenance/updatelibs.go
@@ -61,6 +61,7 @@ func updateOSLibsOnTarget(
 
 type extensionsOptions struct {
 	filterOSLibs bool
+	filterReadme bool
 }
 
 // ExtensionsOption is a functional option for configuring extension retrieval
@@ -70,6 +71,13 @@ type ExtensionsOption func(*extensionsOptions)
 func WithOSLibsFilter() ExtensionsOption {
 	return func(opts *extensionsOptions) {
 		opts.filterOSLibs = true
+	}
+}
+
+// WithReadmeFilter returns only extensions that a README files
+func WithReadmeFilter() ExtensionsOption {
+	return func(opts *extensionsOptions) {
+		opts.filterReadme = true
 	}
 }
 
@@ -104,6 +112,12 @@ func getExtensions(
 		dirName, err := dir.Name(ctx)
 		if err != nil {
 			return nil, err
+		}
+		if options.filterReadme {
+			exists, existsErr := dir.Exists(ctx, readmeFilename)
+			if existsErr != nil || !exists {
+				continue
+			}
 		}
 		extensions[path.Dir(dirName)] = metadata.Name
 	}


### PR DESCRIPTION
## Usage
```shell
dagger \
--progress plain \
call \
-m ./dagger/maintenance/ \
update-readme --help
```
```shell
Updates the container image in the readme for the specified extension(s)

USAGE
  dagger call update-readme [arguments] <function>

ARGUMENTS
      --source Directory   The source directory containing the extension folders. Defaults to the current directory
      --target string      The target extension to update the README. Defaults to "all". (default "all")

```

## Update all readme

```
dagger \
--progress plain \
call \
-m ./dagger/maintenance/ \
update-readme  export --path=.
```

## Update a single readme

```
EXT_NAME=postgis

dagger \
--progress plain \
call \
-m ./dagger/maintenance/ \
update-readme --target $EXT_NAME export --path=.
```

## Renovate wf update

Since Renovate runs in `mend-hosted` environment is not possible to configure/add custom allowed commands.
From [Allowed Post-upgrade commands](https://docs.renovatebot.com/mend-hosted/hosted-apps-config/#allowed-post-upgrade-commands) section 

```
limited set of approved postUpgradeTasks commands are allowed in the app. The commands are not documented, as they may change over time.

You can find the allowed postUpgradeTasks commands in Renovate's log output, when searching for a log line which references [allowedCommands](https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands).
```

from the execution logs 
```
DEBUG: Detected config in env RENOVATE_CONFIG
{
  "config": {
    "extends": [
      "mergeConfidence:all-badges"
    ],
......
    ],
    "platformCommit": "enabled",
    "allowedCommands": [
      "^git add --all$",
      "^git reset$",
      "^pwd$"
    ],
    "repositoryCache": "enabled",

....

``` 

A new workflow will add a new commit only on renovate PR that modify metadata files


Closes #11 


