### PR TITLE
feat: automate e2e env setup

### DIFF
--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Set up environment
         run: |
-          task e2e:env-setup
+          task e2e:setup-env
           task e2e:export-kubeconfig
 
       - name: Generate Chainsaw testing values

--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -130,24 +130,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Create kind cluster
-        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          kubectl_version: ${{ env.KIND_NODE_VERSION }}
-          node_image: kindest/node:${{ env.KIND_NODE_VERSION }}
-          config: kind-config.yaml
+      - name: Install Task
+        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1.0.0
 
-      - name: Install CNPG (${{ matrix.cnpg }})
+      - name: Install Dagger
         env:
-          CNPG_RELEASE: ${{ matrix.cnpg }}
+          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+          DAGGER_VERSION: 0.19.8
         run: |
-          operator_manifest="https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-$CNPG_RELEASE/manifests/operator-manifest.yaml"
-          if [[ "$CNPG_RELEASE" == "main" ]]; then
-            operator_manifest="https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/manifests/operator-manifest.yaml"
-          fi
-          curl -sSfL "$operator_manifest" | kubectl apply --server-side -f -
-          kubectl wait --for=condition=Available --timeout=2m -n cnpg-system deployments cnpg-controller-manager
+          curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+
+      - name: Set up environment
+        run: |
+          task e2e:env-setup
+          task e2e:export-kubeconfig
 
       - name: Generate Chainsaw testing values
         uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644 # v8.2.0

--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -118,12 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{fromJson(needs.testbuild.outputs.images)}}
-        cnpg: ["main", "1.27"]
-    env:
-      # renovate: datasource=github-tags depName=kubernetes-sigs/kind versioning=semver
-      KIND_VERSION: "v0.30.0"
-      # renovate: datasource=docker depName=kindest/node
-      KIND_NODE_VERSION: "v1.34.0"
+        cnpg: ["main", "1.27", "1.28"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -149,7 +144,7 @@ jobs:
         uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644 # v8.2.0
         env:
           # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.19.7
+          DAGGER_VERSION: 0.19.8
         with:
           version: ${{ env.DAGGER_VERSION }}
           verb: call

--- a/BUILD.md
+++ b/BUILD.md
@@ -83,3 +83,33 @@ task DRY_RUN=true
 # or
 task bake TARGET=pgvector DRY_RUN=true
 ```
+
+## Testing locally
+
+Local testing can be performed by using a local Docker container registry and a Kind cluster with CNPG installed.
+The Taskfile includes utilities to set up and tear down such an environment.
+
+### Create a local test environment
+
+The `e2e:setup-env` task takes care of setting up a Kind cluster with a local Docker container registry connected to the same
+Docker network and installs CloudNativePG by default.
+
+```bash
+task e2e:setup-env
+```
+
+The container registry will be exposed locally at `localhost:5000`.
+
+The Kubeconfig to connect to the Kind cluster can be retrieved with:
+
+```bash
+task e2e:export-kubeconfig KUBECONFIG_PATH=<path-to-export-kubeconfig>
+```
+
+### Tear down the local test environment
+
+To clean up all the resources created by the `e2e:setup-env` task, run:
+
+```bash
+task e2e:cleanup
+```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,7 +25,7 @@ tasks:
       - task: bake:all
 
   prereqs:
-    description: Ensure prerequisites are met
+    desc: Ensure prerequisites are met
     run: once
     silent: true
     cmds:
@@ -38,7 +38,7 @@ tasks:
       - echo -e "{{.GREEN}}All prerequisites satisfied!{{.NC}}"
 
   checks:
-    description: Run checks for the specified target
+    desc: Run checks for the specified target
     deps:
       - prereqs
     prefix: 'checks-{{.TARGET}}'
@@ -54,7 +54,7 @@ tasks:
         - name: TARGET
 
   checks:all:
-    description: Run checks for all the available targets
+    desc: Run checks for all the available targets
     vars:
       TARGETS:
         sh: dagger call -sm ./dagger/maintenance/ get-targets | tr -d '[]"' | tr ',' '\n'
@@ -66,7 +66,7 @@ tasks:
         task: checks
 
   bake:
-    description: Bake the specified target
+    desc: Bake the specified target
     deps:
       - prereqs
     prefix: 'bake-{{.TARGET}}'
@@ -91,7 +91,7 @@ tasks:
         - name: TARGET
 
   bake:all:
-    description: Bake all the available targets
+    desc: Bake all the available targets
     vars:
       TARGETS:
         sh: dagger call -sm ./dagger/maintenance/ get-targets | tr -d '[]"' | tr ',' '\n'
@@ -103,7 +103,7 @@ tasks:
         task: bake
 
   update-os-libs:
-    description: Update OS libs on the specified target
+    desc: Update OS libs on the specified target
     deps:
       - prereqs
     prefix: 'update-os-libs-{{.TARGET}}'
@@ -116,7 +116,7 @@ tasks:
         - name: TARGET
 
   update-os-libs:all:
-    description: Update OS libs for all the available targets
+    desc: Update OS libs for all the available targets
     vars:
       TARGETS:
         sh: dagger call -sm ./dagger/maintenance/ get-oslibs-targets | tr -d '[]"' | tr ',' '\n'
@@ -128,17 +128,19 @@ tasks:
         task: update-os-libs
 
   e2e:create-docker-network:
-    description: Create Docker network to connect all the services, such as the Registry, Kind nodes, Chainsaw, etc.
+    desc: Create Docker network to connect all the services, such as the Registry, Kind nodes, Chainsaw, etc.
     run: once
+    internal: true
     cmds:
       - docker network create {{ .E2E_NETWORK }}
     status:
       - docker network inspect {{ .E2E_NETWORK }}
 
   e2e:start-container-registry:
-    description: Start a local Docker registry to push the built images for E2E tests
+    desc: Start a local Docker registry to push the built images for E2E tests
     deps:
       - e2e:create-docker-network
+    internal: true
     run: once
     vars:
       REGISTRY_VERSION: 2
@@ -150,9 +152,10 @@ tasks:
       - test "$(docker inspect -f {{`'{{json .State.Running}}'`}} {{ .REGISTRY_NAME }})" == "true"
 
   e2e:start-dagger-engine:
-    description: Start a custom Dagger engine so we can connect it to the E2E Docker network
+    desc: Start a custom Dagger engine so we can connect it to the E2E Docker network
     deps:
       - e2e:create-docker-network
+    internal: true
     run: once
     vars:
       # TODO: renovate
@@ -165,10 +168,11 @@ tasks:
       - test "$(docker inspect -f {{`'{{json .State.Running}}'`}} {{ .DAGGER_ENGINE_NAME }})" == "true"
 
   e2e:kind-setup:
-    description: Setup Kind cluster for E2E tests
+    desc: Setup Kind cluster for E2E tests
     deps:
       - e2e:start-container-registry
       - e2e:start-dagger-engine
+    internal: true
     run: once
     vars:
       #TODO: renovate
@@ -195,10 +199,11 @@ tasks:
         --socket {{ .DOCKER_SOCKET }} cluster --name {{ .KIND_CLUSTER_NAME }} exist)" == "true"
 
   e2e:cnpg-install:
-    description: Install CloudNativePG operator in the Kind cluster
+    desc: Install CloudNativePG operator in the Kind cluster
     deps:
       - e2e:start-dagger-engine
       - e2e:kind-setup
+    internal: true
     vars:
       # TODO: renovate
       DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
@@ -219,20 +224,25 @@ tasks:
         --socket {{ .DOCKER_SOCKET }} container \
         with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
         
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }}
+        with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec --args="apply","--server-side","-f","{{ .CNPG_MANIFEST }}" --use-entrypoint sync
 
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }}
+        with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
-        with-exec --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager" --use-entrypoint sync
+        with-exec
+        --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager"
+        --use-entrypoint sync
 
   e2e:export-kubeconfig:
-    description: Export Kind cluster kubeconfig
+    desc: Export Kind cluster kubeconfig at path defined by KUBECONFIG_PATH var (default ~/.kube/config)
     deps:
       - e2e:start-dagger-engine
       - e2e:kind-setup
     vars:
+      # TODO: renovate
       DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
       KUBECONFIG_PATH: '{{.KUBECONFIG_PATH| default "~/.kube/config"}}'
       DOCKER_SOCKET:
@@ -248,7 +258,7 @@ tasks:
         echo "${CONFIG}" > {{ .KUBECONFIG_PATH }}
 
   e2e:env-setup:
-    description: Setup E2E environment
+    desc: Setup E2E environment
     silent: true
     deps:
       - e2e:create-docker-network
@@ -260,7 +270,7 @@ tasks:
       - echo -e "{{.GREEN}}--- E2E environment setup complete ---{{.NC}}"
 
   e2e:cleanup:
-    description: Cleanup E2E resources
+    desc: Cleanup E2E resources
     deps:
       - e2e:start-dagger-engine
     vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -218,22 +218,31 @@ tasks:
           fi
     env:
       _EXPERIMENTAL_DAGGER_RUNNER_HOST: container://{{ .DAGGER_ENGINE_NAME }}
+      KUBECONFIG:
+        sh: >
+          dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }}
+          --socket {{ .DOCKER_SOCKET }} container
+          with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout
     cmds:
       - |
-        kubeconfig=$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} \
-        --socket {{ .DOCKER_SOCKET }} container \
-        with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
-        
         dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
-        with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
+        with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec --args="apply","--server-side","-f","{{ .CNPG_MANIFEST }}" --use-entrypoint sync
 
         dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
-        with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
+        with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec \
         --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager" \
+        --use-entrypoint sync
+    status:
+      - >
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }}
+        with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand
+        with-env-variable --name=CACHEBUSTER --value="$(date)"
+        with-exec
+        --args="get","--namespace=cnpg-system","deployments.apps","cnpg-controller-manager"
         --use-entrypoint sync
 
   e2e:export-kubeconfig:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,7 +167,7 @@ tasks:
     status:
       - test "$(docker inspect -f {{`'{{json .State.Running}}'`}} {{ .DAGGER_ENGINE_NAME }})" == "true"
 
-  e2e:kind-setup:
+  e2e:setup-kind:
     desc: Setup Kind cluster for E2E tests
     deps:
       - e2e:start-container-registry
@@ -198,11 +198,11 @@ tasks:
         test "$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }}
         --socket {{ .DOCKER_SOCKET }} cluster --name {{ .KIND_CLUSTER_NAME }} exist)" == "true"
 
-  e2e:cnpg-install:
+  e2e:install-cnpg:
     desc: Install CloudNativePG operator in the Kind cluster
     deps:
       - e2e:start-dagger-engine
-      - e2e:kind-setup
+      - e2e:setup-kind
     internal: true
     vars:
       # TODO: renovate
@@ -224,23 +224,23 @@ tasks:
         --socket {{ .DOCKER_SOCKET }} container \
         with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
         
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }}
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
         with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec --args="apply","--server-side","-f","{{ .CNPG_MANIFEST }}" --use-entrypoint sync
 
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }}
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
         with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
-        with-exec
-        --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager"
+        with-exec \
+        --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager" \
         --use-entrypoint sync
 
   e2e:export-kubeconfig:
     desc: Export Kind cluster kubeconfig at path defined by KUBECONFIG_PATH var (default ~/.kube/config)
     deps:
       - e2e:start-dagger-engine
-      - e2e:kind-setup
+      - e2e:setup-kind
     vars:
       # TODO: renovate
       DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
@@ -257,15 +257,15 @@ tasks:
         mkdir -p $(dirname {{ .KUBECONFIG_PATH }})
         echo "${CONFIG}" > {{ .KUBECONFIG_PATH }}
 
-  e2e:env-setup:
+  e2e:setup-env:
     desc: Setup E2E environment
     silent: true
     deps:
       - e2e:create-docker-network
       - e2e:start-container-registry
       - e2e:start-dagger-engine
-      - e2e:kind-setup
-      - e2e:cnpg-install
+      - e2e:setup-kind
+      - e2e:install-cnpg
     cmds:
       - echo -e "{{.GREEN}}--- E2E environment setup complete ---{{.NC}}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -227,6 +227,26 @@ tasks:
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager" --use-entrypoint sync
 
+  e2e:export-kubeconfig:
+    description: Export Kind cluster kubeconfig
+    deps:
+      - e2e:start-dagger-engine
+      - e2e:kind-setup
+    vars:
+      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
+      KUBECONFIG_PATH: '{{.KUBECONFIG_PATH| default "~/.kube/config"}}'
+      DOCKER_SOCKET:
+        sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
+    env:
+      _EXPERIMENTAL_DAGGER_RUNNER_HOST: container://{{ .DAGGER_ENGINE_NAME }}
+    cmds:
+      - |
+        CONFIG=$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} \
+          --socket {{ .DOCKER_SOCKET }} container \
+          with-exec --args "kind","get","kubeconfig","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
+        mkdir -p $(dirname {{ .KUBECONFIG_PATH }})
+        echo "${CONFIG}" > {{ .KUBECONFIG_PATH }}
+
   e2e:env-setup:
     description: Setup E2E environment
     silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -201,7 +201,6 @@ tasks:
   e2e:install-cnpg:
     desc: Install CloudNativePG operator in the Kind cluster
     deps:
-      - e2e:start-dagger-engine
       - e2e:setup-kind
     internal: true
     vars:
@@ -218,13 +217,12 @@ tasks:
           fi
     env:
       _EXPERIMENTAL_DAGGER_RUNNER_HOST: container://{{ .DAGGER_ENGINE_NAME }}
-      KUBECONFIG:
-        sh: >
-          dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }}
-          --socket {{ .DOCKER_SOCKET }} container
-          with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout
     cmds:
       - |
+        KUBECONFIG=$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} \
+          --socket {{ .DOCKER_SOCKET }} container \
+          with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
+        
         dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
         with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
@@ -237,18 +235,20 @@ tasks:
         --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager" \
         --use-entrypoint sync
     status:
-      - >
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }}
-        with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand
-        with-env-variable --name=CACHEBUSTER --value="$(date)"
-        with-exec
-        --args="get","--namespace=cnpg-system","deployments.apps","cnpg-controller-manager"
+      - |
+        KUBECONFIG=$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} \
+          --socket {{ .DOCKER_SOCKET }} container \
+          with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
+        with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand \
+        with-env-variable --name=CACHEBUSTER --value="$(date)" \
+        with-exec \
+        --args="get","--namespace=cnpg-system","deployments.apps","cnpg-controller-manager" \
         --use-entrypoint sync
 
   e2e:export-kubeconfig:
     desc: Export Kind cluster kubeconfig at path defined by KUBECONFIG_PATH var (default ~/.kube/config)
     deps:
-      - e2e:start-dagger-engine
       - e2e:setup-kind
     vars:
       # TODO: renovate
@@ -270,10 +270,8 @@ tasks:
     desc: Setup E2E environment
     silent: true
     deps:
-      - e2e:create-docker-network
       - e2e:start-container-registry
       - e2e:start-dagger-engine
-      - e2e:setup-kind
       - e2e:install-cnpg
     cmds:
       - echo -e "{{.GREEN}}--- E2E environment setup complete ---{{.NC}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,10 +12,11 @@ vars:
   DAGGER_ENGINE_NAME: dagger-engine-pg-extensions
   REGISTRY_NAME: registry.pg-extensions
   REGISTRY_HOST_PORT: 5000
-  # TODO: renovate
-  K8S_VERSION: 1.34.2
-  # TODO: renovate ?
-  CNPG_RELEASE: 1.28
+  # renovate: datasource=git-refs depName=kind lookupName=https://github.com/aweris/daggerverse currentValue=main
+  DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
+  # renovate: datasource=docker depName=kindest/node versioning=docker
+  KIND_NODE_VERSION: v1.34.2@sha256:745f8ed46d8e99517774768227fd1a0af34a6bf395aef9c7ed98fbce0e263918
+  K8S_VERSION: '{{ regexReplaceAll "^v([0-9.]+).*" .KIND_NODE_VERSION "$1" }}'
   KIND_CLUSTER_NAME: pg-extensions-{{ .K8S_VERSION }}
 
 tasks:
@@ -143,7 +144,8 @@ tasks:
     internal: true
     run: once
     vars:
-      REGISTRY_VERSION: 2
+      # renovate: datasource=docker depName=registry versioning=docker
+      REGISTRY_VERSION: 3.0.0@sha256:cd92709b4191c5779cd7215ccd695db6c54652e7a62843197e367427efb84d0e
     cmds:
       - >
         docker run -d --name {{ .REGISTRY_NAME }} --rm -p {{ .REGISTRY_HOST_PORT }}:5000
@@ -158,7 +160,7 @@ tasks:
     internal: true
     run: once
     vars:
-      # TODO: renovate
+      # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
       DAGGER_ENGINE_VERSION: v0.19.8
     cmds:
       - >
@@ -175,8 +177,6 @@ tasks:
     internal: true
     run: once
     vars:
-      #TODO: renovate
-      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
       REGISTRY_DIR: /etc/containerd/certs.d/localhost:{{ .REGISTRY_HOST_PORT }}
       DOCKER_SOCKET:
         sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
@@ -187,7 +187,7 @@ tasks:
         dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} --socket {{ .DOCKER_SOCKET }}
         container with-env-variable --name=KIND_EXPERIMENTAL_DOCKER_NETWORK --value={{ .E2E_NETWORK }} with-env-variable --name=CACHE_BUSTER --value="$(date)"
         with-file --source=kind-config.yaml --path=/root/kind-config.yaml
-        with-exec --args="kind","create","cluster","--name","{{ .KIND_CLUSTER_NAME }}","--image","kindest/node:v{{ .K8S_VERSION }}","--config","/root/kind-config.yaml" sync
+        with-exec --args="kind","create","cluster","--name","{{ .KIND_CLUSTER_NAME }}","--image","kindest/node:{{ .KIND_NODE_VERSION }}","--config","/root/kind-config.yaml" sync
       - docker exec "{{ .KIND_CLUSTER_NAME }}-control-plane" mkdir -p "{{ .REGISTRY_DIR }}"
       - |
         cat <<EOF | docker exec -i "{{ .KIND_CLUSTER_NAME }}-control-plane" cp /dev/stdin "{{ .REGISTRY_DIR }}/hosts.toml"
@@ -204,8 +204,10 @@ tasks:
       - e2e:setup-kind
     internal: true
     vars:
-      # TODO: renovate
-      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
+      # renovate: datasource=github-tags depName=cloudnative-pg/cloudnative-pg versioning=semver extractVersion=^v(?<version>\d+\.\d+)\.\d+$
+      CNPG_RELEASE: 1.28
+      # renovate: datasource=docker depName=alpine/kubectl versioning=docker
+      KUBECTL_VERSION: 1.34.2@sha256:96a7d245a74d461925a56e3024d2f027c2a7a822b3e9e0117ec558db42de9c35
       DOCKER_SOCKET:
         sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
       CNPG_MANIFEST:
@@ -222,13 +224,13 @@ tasks:
         KUBECONFIG=$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} \
           --socket {{ .DOCKER_SOCKET }} container \
           with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
-        
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
+
+        dagger core container from --address=alpine/kubectl:{{ .KUBECTL_VERSION }} \
         with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec --args="apply","--server-side","-f","{{ .CNPG_MANIFEST }}" --use-entrypoint sync
 
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
+        dagger core container from --address=alpine/kubectl:{{ .KUBECTL_VERSION }} \
         with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec \
@@ -239,7 +241,7 @@ tasks:
         KUBECONFIG=$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} \
           --socket {{ .DOCKER_SOCKET }} container \
           with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
-        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} \
+        dagger core container from --address=alpine/kubectl:{{ .KUBECTL_VERSION }} \
         with-new-file --contents "${KUBECONFIG}" --path /root/.kube/config --expand \
         with-env-variable --name=CACHEBUSTER --value="$(date)" \
         with-exec \
@@ -251,8 +253,6 @@ tasks:
     deps:
       - e2e:setup-kind
     vars:
-      # TODO: renovate
-      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
       KUBECONFIG_PATH: '{{.KUBECONFIG_PATH| default "~/.kube/config"}}'
       DOCKER_SOCKET:
         sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
@@ -281,8 +281,6 @@ tasks:
     deps:
       - e2e:start-dagger-engine
     vars:
-      # TODO: renovate
-      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
       DOCKER_SOCKET:
         sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
     env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -162,7 +162,7 @@ tasks:
       DAGGER_ENGINE_VERSION: v0.19.8
     cmds:
       - >
-        docker run -d -v /var/lib/dagger --name {{ .DAGGER_ENGINE_NAME }} --rm --network {{ .E2E_NETWORK }}
+        docker run -d -v /var/lib/dagger --name {{ .DAGGER_ENGINE_NAME }} --restart always --network {{ .E2E_NETWORK }}
         --privileged registry.dagger.io/engine:{{ .DAGGER_ENGINE_VERSION }}
     status:
       - test "$(docker inspect -f {{`'{{json .State.Running}}'`}} {{ .DAGGER_ENGINE_NAME }})" == "true"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,16 @@ vars:
   RED: \033[0;31m
   NC: \033[0m
 
+  E2E_NETWORK: pg-extensions-e2e
+  DAGGER_ENGINE_NAME: dagger-engine-pg-extensions
+  REGISTRY_NAME: registry.pg-extensions
+  REGISTRY_HOST_PORT: 5000
+  # TODO: renovate
+  K8S_VERSION: 1.34.2
+  # TODO: renovate ?
+  CNPG_RELEASE: 1.28
+  KIND_CLUSTER_NAME: pg-extensions-{{ .K8S_VERSION }}
+
 tasks:
   default:
     desc: Build all targets (default)
@@ -116,3 +126,134 @@ tasks:
         vars:
           TARGET: "{{.ITEM}}"
         task: update-os-libs
+
+  e2e:create-docker-network:
+    description: Create Docker network to connect all the services, such as the Registry, Kind nodes, Chainsaw, etc.
+    run: once
+    cmds:
+      - docker network create {{ .E2E_NETWORK }}
+    status:
+      - docker network inspect {{ .E2E_NETWORK }}
+
+  e2e:start-container-registry:
+    description: Start a local Docker registry to push the built images for E2E tests
+    deps:
+      - e2e:create-docker-network
+    run: once
+    vars:
+      REGISTRY_VERSION: 2
+    cmds:
+      - >
+        docker run -d --name {{ .REGISTRY_NAME }} --rm -p {{ .REGISTRY_HOST_PORT }}:5000
+        --network {{ .E2E_NETWORK }} registry:{{ .REGISTRY_VERSION }}
+    status:
+      - test "$(docker inspect -f {{`'{{json .State.Running}}'`}} {{ .REGISTRY_NAME }})" == "true"
+
+  e2e:start-dagger-engine:
+    description: Start a custom Dagger engine so we can connect it to the E2E Docker network
+    deps:
+      - e2e:create-docker-network
+    run: once
+    vars:
+      # TODO: renovate
+      DAGGER_ENGINE_VERSION: v0.19.8
+    cmds:
+      - >
+        docker run -d -v /var/lib/dagger --name {{ .DAGGER_ENGINE_NAME }} --rm --network {{ .E2E_NETWORK }}
+        --privileged registry.dagger.io/engine:{{ .DAGGER_ENGINE_VERSION }}
+    status:
+      - test "$(docker inspect -f {{`'{{json .State.Running}}'`}} {{ .DAGGER_ENGINE_NAME }})" == "true"
+
+  e2e:kind-setup:
+    description: Setup Kind cluster for E2E tests
+    deps:
+      - e2e:start-container-registry
+      - e2e:start-dagger-engine
+    run: once
+    vars:
+      #TODO: renovate
+      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
+      REGISTRY_DIR: /etc/containerd/certs.d/localhost:{{ .REGISTRY_HOST_PORT }}
+      DOCKER_SOCKET:
+        sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
+    env:
+      _EXPERIMENTAL_DAGGER_RUNNER_HOST: container://{{ .DAGGER_ENGINE_NAME }}
+    cmds:
+      - >
+        dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} --socket {{ .DOCKER_SOCKET }}
+        container with-env-variable --name=KIND_EXPERIMENTAL_DOCKER_NETWORK --value={{ .E2E_NETWORK }} with-env-variable --name=CACHE_BUSTER --value="$(date)"
+        with-file --source=kind-config.yaml --path=/root/kind-config.yaml
+        with-exec --args="kind","create","cluster","--name","{{ .KIND_CLUSTER_NAME }}","--image","kindest/node:v{{ .K8S_VERSION }}","--config","/root/kind-config.yaml" sync
+      - docker exec "{{ .KIND_CLUSTER_NAME }}-control-plane" mkdir -p "{{ .REGISTRY_DIR }}"
+      - |
+        cat <<EOF | docker exec -i "{{ .KIND_CLUSTER_NAME }}-control-plane" cp /dev/stdin "{{ .REGISTRY_DIR }}/hosts.toml"
+        [host."http://{{ .REGISTRY_NAME }}:5000"]
+        EOF
+    status:
+      - >
+        test "$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }}
+        --socket {{ .DOCKER_SOCKET }} cluster --name {{ .KIND_CLUSTER_NAME }} exist)" == "true"
+
+  e2e:cnpg-install:
+    description: Install CloudNativePG operator in the Kind cluster
+    deps:
+      - e2e:start-dagger-engine
+      - e2e:kind-setup
+    vars:
+      # TODO: renovate
+      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
+      DOCKER_SOCKET:
+        sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
+      CNPG_MANIFEST:
+        sh: |
+          if [ "{{ .CNPG_RELEASE }}" = "main" ]; then
+            echo "https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/manifests/operator-manifest.yaml"
+          else
+            echo "https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-{{ .CNPG_RELEASE }}/manifests/operator-manifest.yaml"
+          fi
+    env:
+      _EXPERIMENTAL_DAGGER_RUNNER_HOST: container://{{ .DAGGER_ENGINE_NAME }}
+    cmds:
+      - |
+        kubeconfig=$(dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }} \
+        --socket {{ .DOCKER_SOCKET }} container \
+        with-exec --args "kind","get","kubeconfig","--internal","--name","{{ .KIND_CLUSTER_NAME }}" stdout)
+        
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
+        with-env-variable --name=CACHEBUSTER --value="$(date)" \
+        with-exec --args="apply","--server-side","-f","{{ .CNPG_MANIFEST }}" --use-entrypoint sync
+
+        dagger core container from --address=alpine/kubectl:{{ .K8S_VERSION }} with-new-file --contents "${kubeconfig}" --path /root/.kube/config --expand \
+        with-env-variable --name=CACHEBUSTER --value="$(date)" \
+        with-exec --args="wait","--for=condition=Available","--timeout=2m","-n","cnpg-system","deployments","cnpg-controller-manager" --use-entrypoint sync
+
+  e2e:env-setup:
+    description: Setup E2E environment
+    silent: true
+    deps:
+      - e2e:create-docker-network
+      - e2e:start-container-registry
+      - e2e:start-dagger-engine
+      - e2e:kind-setup
+      - e2e:cnpg-install
+    cmds:
+      - echo -e "{{.GREEN}}--- E2E environment setup complete ---{{.NC}}"
+
+  e2e:cleanup:
+    description: Cleanup E2E resources
+    deps:
+      - e2e:start-dagger-engine
+    vars:
+      # TODO: renovate
+      DAGGER_KIND_SHA: dadbc09a1e0790ccbf1d88f796308b26a12f0488
+      DOCKER_SOCKET:
+        sh: docker context inspect -f {{`'{{json .Endpoints.docker.Host}}'`}} $(docker context show)
+    env:
+      _EXPERIMENTAL_DAGGER_RUNNER_HOST: container://{{ .DAGGER_ENGINE_NAME }}
+    cmds:
+      - >
+        dagger call -m github.com/aweris/daggerverse/kind@{{ .DAGGER_KIND_SHA }}
+        --socket {{ .DOCKER_SOCKET }} cluster --name {{ .KIND_CLUSTER_NAME }} delete || true
+      - docker rm -fv {{ .DAGGER_ENGINE_NAME }} || true
+      - docker rm -fv {{ .REGISTRY_NAME }} || true
+      - docker network rm {{ .E2E_NETWORK }} || true

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -4,5 +4,5 @@ featureGates:
   ImageVolume: true
 containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry]
+    [plugins."io.containerd.cri.v1.images".registry]
       config_path = "/etc/containerd/certs.d"

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -2,3 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   ImageVolume: true
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"

--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,7 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: currentValue=(?<currentValue>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_SHA\\s*:\\s*[\"']?(?<currentDigest>[a-f0-9]+?)[\"']?\\s",
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?(?<currentValue>[^@]+?)(@(?<currentDigest>.+))?[\"']?\\s"
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
       ]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,17 @@
       "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",
       "datasourceTemplate": "deb",
       "extractVersionTemplate": "^(?<version>[^-+]+)"
+    },
+    {
+      "description": "updates the Taskfile dependencies",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "Taskfile.yml"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: currentValue=(?<currentValue>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_SHA\\s*:\\s*[\"']?(?<currentDigest>[a-f0-9]+?)[\"']?\\s",
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?(?<currentValue>[^@]+?)(@(?<currentDigest>.+))?[\"']?\\s"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Add tasks to bootstrap a kind environment with ImageVolume feature gate enabled and install CNPG operator. Everything runs through dagger so no additional runtime dependencies are required.

Test:
```
task e2e:setup-env
```

TODO: renovate on sha/versions in taskfile

closes #55 