### PR TITLE
ci: automate versions update in README.md files

### DIFF
--- a/pgaudit/README.md
+++ b/pgaudit/README.md
@@ -34,7 +34,7 @@ spec:
     extensions:
     - name: pgaudit
       image:
-        # renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
+        # renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit
         reference: ghcr.io/cloudnative-pg/pgaudit:18.0-18-trixie
 ```
 
@@ -55,7 +55,7 @@ spec:
     name: cluster-pgaudit
   extensions:
   - name: pgaudit
-    # renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
+    # renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit
     version: '18.0'
 ```
 

--- a/pgaudit/README.md
+++ b/pgaudit/README.md
@@ -34,6 +34,7 @@ spec:
     extensions:
     - name: pgaudit
       image:
+        # renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
         reference: ghcr.io/cloudnative-pg/pgaudit:18.0-18-trixie
 ```
 
@@ -54,6 +55,7 @@ spec:
     name: cluster-pgaudit
   extensions:
   - name: pgaudit
+    # renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
     version: '18.0'
 ```
 

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -29,6 +29,7 @@ spec:
     extensions:
     - name: pgvector
       image:
+        # renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
         reference: ghcr.io/cloudnative-pg/pgvector:0.8.1-18-trixie
 ```
 
@@ -49,6 +50,7 @@ spec:
     name: cluster-pgvector
   extensions:
   - name: vector
+    # renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
     version: '0.8.1'
 ```
 

--- a/postgis/README.md
+++ b/postgis/README.md
@@ -28,6 +28,7 @@ spec:
     extensions:
     - name: postgis
       image:
+        # renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
         reference: ghcr.io/cloudnative-pg/postgis-extension:3.6.1-18-trixie
       ld_library_path:
       - system
@@ -50,6 +51,7 @@ spec:
     name: cluster-postgis
   extensions:
   - name: postgis
+    # renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
     version: '3.6.1'
   - name: postgis_raster
   - name: postgis_sfcgal

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "**/README.md"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*reference: ghcr.io\\/cloudnative-pg\\/[A-Za-z0-9_-]+.*:(?<currentValue>([0-9]\\.?)+)",
+        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*reference: ghcr.io\\/cloudnative-pg\\/[A-Za-z0-9_-]+:(?<currentValue>([0-9]\\.?)+)",
         "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*version: '(?<currentValue>([0-9]\\.?)+)'"
       ],
       "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   ],
   "customManagers": [
     {
+      "description": "updates the deb package versions in the metadata.hcl files",
       "customType": "regex",
       "managerFilePatterns": [
         "**/*.hcl"
@@ -20,6 +21,20 @@
       ],
       "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",
       "datasourceTemplate": "deb"
+    },
+    {
+      "description": "updates the container image versions in the README.md files",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "**/README.md"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*reference: ghcr.io\\/cloudnative-pg\\/[A-Za-z0-9_-]+.*:(?<currentValue>([0-9]\\.?)+)",
+        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*version: '(?<currentValue>([0-9]\\.?)+)'"
+      ],
+      "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",
+      "datasourceTemplate": "deb",
+      "extractVersionTemplate": "^(?<version>[^-+]+)"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Add a renovate custom manager to update the extension versions in the Cluster and Database resources in
the README examples.

closes #11 