### PR TITLE
feat: support required extensions

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -328,6 +328,9 @@ tasks:
             # We need to replace localhost with the registry container name as it is how
             # the registry is reachable from within the Docker network.
             sh: sed -E 's/^localhost/{{ .REGISTRY_NAME }}/;t' <<< "{{ .EXTENSION_IMAGE }}"
+    requires:
+      vars:
+        - name: TARGET
 
   e2e:test:
     desc: Test target extension using Chainsaw

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -178,15 +178,11 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage)
 	}
 
-	extensions, generateExtErr := generateTestingValuesExtensions(
-		ctx,
-		source,
-		metadata,
-		targetExtensionImage,
-	)
-	if generateExtErr != nil {
-		return nil, generateExtErr
+	extensions, err := generateTestingValuesExtensions(ctx, source, metadata, targetExtensionImage)
+	if err != nil {
+		return nil, err
 	}
+
 	// Build values.yaml content
 	values := map[string]any{
 		"name":                     metadata.Name,

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -28,6 +28,7 @@ type extensionMetadata struct {
 	DynamicLibraryPath     []string   `hcl:"dynamic_library_path" cty:"dynamic_library_path"`
 	LdLibraryPath          []string   `hcl:"ld_library_path" cty:"ld_library_path"`
 	AutoUpdateOsLibs       bool       `hcl:"auto_update_os_libs" cty:"auto_update_os_libs"`
+	RequiredExtensions     []string   `hcl:"required_extensions" cty:"required_extensions"`
 	Versions               versionMap `hcl:"versions" cty:"versions"`
 	Remain                 hcl.Body   `hcl:",remain"`
 }

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -98,7 +98,7 @@ func parseExtensionMetadata(ctx context.Context, extensionDirectory *dagger.Dire
 		return nil, err
 	}
 	if !hasMetadataFile {
-		return nil, fmt.Errorf("not a valid target, metadata.hcl file is missing")
+		return nil, fmt.Errorf("metadata.hcl file is missing")
 	}
 
 	data, err := extensionDirectory.File(metadataFile).Contents(ctx)

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path"
 
 	"github.com/docker/buildx/bake"
@@ -90,6 +91,14 @@ func parseExtensionMetadata(ctx context.Context, extensionDirectory *dagger.Dire
 	type Config struct {
 		Metadata extensionMetadata `hcl:"metadata"`
 		Remain   hcl.Body          `hcl:",remain"`
+	}
+
+	hasMetadataFile, err := extensionDirectory.Exists(ctx, metadataFile)
+	if err != nil {
+		return nil, err
+	}
+	if !hasMetadataFile {
+		return nil, fmt.Errorf("not a valid target, metadata.hcl file is missing")
 	}
 
 	data, err := extensionDirectory.File(metadataFile).Contents(ctx)

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+
+	"dagger/maintenance/internal/dagger"
+)
+
+func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directory, metadata *extensionMetadata, extensionImage string) ([]map[string]any, error) {
+	var out []map[string]any
+	configuration, err := generateExtensionConfiguration(metadata, extensionImage)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, configuration)
+	for _, deps := range metadata.RequiredExtensions {
+		depsMetadata, parseErr := parseExtensionMetadata(ctx, source.Directory(deps))
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		depsConfiguration, extErr := generateExtensionConfiguration(depsMetadata, "")
+		if extErr != nil {
+			return nil, extErr
+		}
+		out = append(out, depsConfiguration)
+
+	}
+	return out, nil
+}
+
+func generateExtensionConfiguration(metadata *extensionMetadata, extensionImage string) (map[string]any, error) {
+	targetExtensionImage := extensionImage
+	if targetExtensionImage == "" {
+		var err error
+		targetExtensionImage, err = getDefaultExtensionImage(metadata)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return map[string]any{
+		"name": metadata.Name,
+		"image": map[string]string{
+			"reference": targetExtensionImage,
+		},
+		"extension_control_path": metadata.ExtensionControlPath,
+		"dynamic_library_path":   metadata.DynamicLibraryPath,
+		"ld_library_path":        metadata.LdLibraryPath,
+	}, nil
+}

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -26,7 +26,7 @@ func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directo
 
 		depMetadata, parseErr := parseExtensionMetadata(ctx, source.Directory(dep))
 		if parseErr != nil {
-			return nil, parseErr
+			return nil, fmt.Errorf("failed to parse dependency metadata %q: %w", dep, parseErr)
 		}
 		depsConfiguration, extErr := generateExtensionConfiguration(depMetadata, "")
 		if extErr != nil {

--- a/pgaudit/metadata.hcl
+++ b/pgaudit/metadata.hcl
@@ -7,6 +7,7 @@ metadata = {
   dynamic_library_path     = []
   ld_library_path          = []
   auto_update_os_libs      = false
+  required_extensions      = []
 
   versions = {
     bookworm = {

--- a/pgvector/metadata.hcl
+++ b/pgvector/metadata.hcl
@@ -7,6 +7,7 @@ metadata = {
   dynamic_library_path     = []
   ld_library_path          = []
   auto_update_os_libs      = false
+  required_extensions      = []
 
   versions = {
     bookworm = {

--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -7,6 +7,7 @@ metadata = {
   dynamic_library_path     = []
   ld_library_path          = ["/system"]
   auto_update_os_libs      = true
+  required_extensions      = []
 
   versions = {
     bookworm = {

--- a/postgis/test/cluster.yaml
+++ b/postgis/test/cluster.yaml
@@ -11,10 +11,4 @@ spec:
 
   postgresql:
     shared_preload_libraries: ($values.shared_preload_libraries)
-    extensions:
-      - name: ($values.name)
-        image:
-          reference: ($values.extension_image)
-        extension_control_path: ($values.extension_control_path)
-        dynamic_library_path: ($values.dynamic_library_path)
-        ld_library_path: ($values.ld_library_path)
+    extensions: ($values.extensions)

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -9,6 +9,7 @@ metadata = {
   dynamic_library_path     = []
   ld_library_path          = []
   auto_update_os_libs      = false
+  required_extensions      = []
 
   versions = {
     {{- range $distro := .Distros}}

--- a/test/cluster.yaml
+++ b/test/cluster.yaml
@@ -11,10 +11,4 @@ spec:
 
   postgresql:
     shared_preload_libraries: ($values.shared_preload_libraries)
-    extensions:
-      - name: ($values.name)
-        image:
-          reference: ($values.extension_image)
-        extension_control_path: ($values.extension_control_path)
-        dynamic_library_path: ($values.dynamic_library_path)
-        ld_library_path: ($values.ld_library_path)
+    extensions: ($values.extensions)


### PR DESCRIPTION
## initial support for extensions dependencies

introduce a new field in the metadata spec to define a list of required extensions

supposing a metadata file like 

```hcl
metadata = {
  name                     = "pgrouting"
  sql_name                 = "pgrouting"
  image_name               = "pgrouting"
  shared_preload_libraries = []
  extension_control_path   = []
  dynamic_library_path     = []
  ld_library_path          = []
  auto_update_os_libs      = false
  required_extensions      = [
      "postgis",
  ]

  versions = {
    bookworm = {
      "18" = ":4.0.0+dfsg-1.pgdg12+1"
    }
    trixie = {
      "18" = "4.0.0+dfsg-1.pgdg13+1"
    }
  }
}

```

the command `generate-testing-values` command will generate the proper extensions like

```shell
dagger \
call \
-m ./dagger/maintenance/ \
generate-testing-values --target pgrouting --extension-image ghcr.io/cloudnative-pg/pgrouting:4.0.0-18-bookworm export --path=pgrouting/values.yaml
```

```yaml
extensions:
    - dynamic_library_path: []
      extension_control_path: []
      image:
        reference: ghcr.io/cloudnative-pg/pgrouting:4.0.0-18-bookworm
      ld_library_path: []
      name: pgrouting
    - dynamic_library_path: []
      extension_control_path: []
      image:
        reference: ghcr.io/cloudnative-pg/postgis-extension:3.6.1-18-bookworm
      ld_library_path:
        - /system
      name: postgis
name: pgrouting
pg_image: ghcr.io/cloudnative-pg/postgresql:18-minimal-bookworm
sql_name: pgrouting
version: 4.0.0

```


closes #18 