### PR TITLE
feat: e2e test as single task cmd

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -106,8 +106,15 @@ execution:
 task e2e:test:full TARGET="<extension>"
 ```
 
-If issues arise, follow the step-by-step guide below for granular
-troubleshooting.
+Example for testing the `pgvector` extension:
+
+```bash
+task e2e:test:full TARGET="pgvector"
+```
+
+**When to use the step-by-step guide:** If the automated test fails during
+environment setup, image building, or test execution, the step-by-step guide
+below provides granular control for debugging each phase independently.
 
 ---
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -94,6 +94,22 @@ cluster with CloudNativePG pre-installed.
 > **Pre-submission requirement:** You must successfully run local tests before
 > submitting a Pull Request for any extension.
 
+### Run e2e tests for a specific extension
+
+E2E tests are performed using [Chainsaw](https://github.com/kyverno/chainsaw)
+which enables declarative testing through a set of specific manifests.
+The Taskfile collects all the necessary steps to setup the environment and
+to execute the tests into a single command:
+
+```bash
+task e2e:test:full TARGET="<extension>"
+```
+
+If issues arise, follow the step-by-step guide below for easier
+troubleshooting and a better understanding of the process.
+
+## E2E Step by Step Guide
+
 ### Initialize the environment
 
 The `e2e:setup-env` utility automates the heavy lifting. It creates a Kind

--- a/BUILD.md
+++ b/BUILD.md
@@ -166,7 +166,7 @@ generic tests (global `/test` folder) and extension-specific tests (target
 `/test` folder).
 
 ```bash
-task e2e:export-kubeconfig KUBECONFIG_PATH=./kubeconfig INTERNAL=true
+task e2e:test TARGET="<extension>" KUBECONFIG_PATH="./kubeconfig"
 ```
 
 ---

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -349,6 +349,7 @@ tasks:
     vars:
       METADATA_FILE: "{{ .TARGET }}/bake-metadata.json"
       KUBECONFIG_PATH: "./kubeconfig"
+      DISTRO: '{{ .DISTRO | default "trixie" }}'
     cmds:
       - task: e2e:setup-env
       - task: bake
@@ -362,9 +363,10 @@ tasks:
           TARGET: "{{ .TARGET }}"
           EXTENSION_IMAGE:
             sh: >
-              jq 'to_entries | .[] | select(.key | endswith("-trixie")) | .value["image.name"] | split(",")[0]'
+              jq -r --arg distro "{{ .DISTRO }}"
+              'to_entries | .[] | select(.key | endswith("-" + $distro)) | .value["image.name"] | split(",")[0]'
               "{{ .METADATA_FILE }}"
-      - defer: rm -f {{ .TARGET }}/values.yaml
+      - defer: rm -f "{{ .TARGET }}/values.yaml"
       - task: e2e:export-kubeconfig
         vars:
           KUBECONFIG_PATH: "{{ .KUBECONFIG_PATH }}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,6 +75,7 @@ tasks:
     vars:
       PUSH: '{{.PUSH | default "false"}}'
       DRY_RUN: '{{.DRY_RUN | default "false"}}'
+      METADATA_FILE: '{{.METADATA_FILE | default ""}}'
     preconditions:
       - sh: test -f "{{.TARGET}}/metadata.hcl"
         msg: 'Not a valid target, metadata.hcl file is missing. Target: {{.TARGET}}'
@@ -82,9 +83,9 @@ tasks:
       - echo -e "{{.BLUE}}Baking target {{.TARGET}} (push={{.PUSH}})...{{.NC}}"
       - |
         if [ "{{.DRY_RUN}}" = "true" ]; then
-          echo -e "{{.GREEN}}[DRY RUN] docker buildx bake -f {{.TARGET}}/metadata.hcl -f docker-bake.hcl --push={{.PUSH}}{{.NC}}"
+          echo -e "{{.GREEN}}[DRY RUN] docker buildx bake -f {{.TARGET}}/metadata.hcl -f docker-bake.hcl --metadata-file="{{.METADATA_FILE}}" --push={{.PUSH}}{{.NC}}"
         else
-          docker buildx bake -f {{.TARGET}}/metadata.hcl -f docker-bake.hcl --push={{.PUSH}}
+          docker buildx bake -f {{.TARGET}}/metadata.hcl -f docker-bake.hcl --metadata-file="{{.METADATA_FILE}}" --push={{.PUSH}}
         fi
       - echo -e "{{.GREEN}}--- Successfully baked {{.TARGET}} ---{{.NC}}"
     requires:
@@ -342,6 +343,40 @@ tasks:
         vars:
           TARGET: "{{ .ITEM }}"
         task: e2e:test
+
+  e2e:test:full:
+    desc: "Run full E2E tests: setup env, generate values, run tests"
+    vars:
+      METADATA_FILE: "{{ .TARGET }}/bake-metadata.json"
+      KUBECONFIG_PATH: "./kubeconfig"
+    cmds:
+      - task: e2e:setup-env
+      - task: bake
+        vars:
+          PUSH: "true"
+          TARGET: "{{ .TARGET }}"
+          METADATA_FILE: "{{ .METADATA_FILE }}"
+      - defer: rm -f "{{ .METADATA_FILE }}"
+      - task: e2e:generate-values
+        vars:
+          TARGET: "{{ .TARGET }}"
+          EXTENSION_IMAGE:
+            sh: >
+              jq 'to_entries | .[] | select(.key | endswith("-trixie")) | .value["image.name"] | split(",")[0]'
+              "{{ .METADATA_FILE }}"
+      - defer: rm -f {{ .TARGET }}/values.yaml
+      - task: e2e:export-kubeconfig
+        vars:
+          KUBECONFIG_PATH: "{{ .KUBECONFIG_PATH }}"
+          INTERNAL: "true"
+      - defer: rm -f "{{ .KUBECONFIG_PATH }}"
+      - task: e2e:test
+        vars:
+          TARGET: "{{ .TARGET }}"
+          KUBECONFIG_PATH: "{{ .KUBECONFIG_PATH }}"
+    requires:
+      vars:
+        - name: TARGET
 
   e2e:cleanup:
     desc: Cleanup E2E resources


### PR DESCRIPTION
Provide e2e test execution for extensions as a single Taskfile command rather than having to chain multiple steps externally

Test:

` task e2e:test:full TARGET=pgvector`

closes #80 