### PR TITLE
feat: generate a k8s_name for test

### DIFF
--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -174,9 +174,12 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage)
 	}
 
+	k8sName := strings.ReplaceAll(metadata.Name, "_", "-")
+
 	// Build values.yaml content
 	values := map[string]any{
 		"name":                     metadata.Name,
+		"k8s_name":                 k8sName,
 		"sql_name":                 metadata.SQLName,
 		"image_name":               metadata.ImageName,
 		"shared_preload_libraries": metadata.SharedPreloadLibraries,

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -174,6 +174,10 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage)
 	}
 
+	// Sanitize the extension name for Kubernetes compatibility.
+	// Underscores are valid in extension metadata but prohibited in K8s
+	// object names, which must follow DNS subdomain conventions
+	// (RFC-1123).
 	k8sName := strings.ReplaceAll(metadata.Name, "_", "-")
 
 	// Build values.yaml content

--- a/postgis/test/check-extension.yaml
+++ b/postgis/test/check-extension.yaml
@@ -14,7 +14,7 @@ spec:
           - name: DB_URI
             valueFrom:
               secretKeyRef:
-                name: (join('-', [$values.name, 'app']))
+                name: (join('-', [$values.k8s_name, 'app']))
                 key: uri
         image: alpine/psql:latest
         command: ['sh', '-c']

--- a/postgis/test/cluster-assert.yaml
+++ b/postgis/test/cluster-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: ($values.name)
+  name: ($values.k8s_name)
 status:
   readyInstances: 1
   phase: Cluster in healthy state

--- a/postgis/test/cluster.yaml
+++ b/postgis/test/cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: ($values.name)
+  name: ($values.k8s_name)
 spec:
   imageName: ($values.pg_image)
   instances: 1
@@ -12,7 +12,7 @@ spec:
   postgresql:
     shared_preload_libraries: ($values.shared_preload_libraries)
     extensions:
-      - name: ($values.name)
+      - name: ($values.k8s_name)
         image:
           reference: ($values.extension_image)
         extension_control_path: ($values.extension_control_path)

--- a/postgis/test/database-assert.yaml
+++ b/postgis/test/database-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: (join('-', [$values.name, 'app']))
+  name: (join('-', [$values.k8s_name, 'app']))
 status:
   applied: true
   extensions:

--- a/postgis/test/database.yaml
+++ b/postgis/test/database.yaml
@@ -1,12 +1,12 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: (join('-', [$values.name, 'app']))
+  name: (join('-', [$values.k8s_name, 'app']))
 spec:
   name: app
   owner: app
   cluster:
-    name: ($values.name)
+    name: ($values.k8s_name)
   extensions:
   - name: ($values.sql_name)
     version: ($values.version)

--- a/templates/README.md.tmpl
+++ b/templates/README.md.tmpl
@@ -29,7 +29,7 @@ your `Cluster` resource. For example:
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cluster-{{ .Name }}
+  name: cluster-{{ replaceAll .Name "_" "-" }}
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:{{ .DefaultVersion }}-minimal-{{ .DefaultDistro }}
   instances: 1
@@ -39,7 +39,7 @@ spec:
 
   postgresql:
     extensions:
-    - name: {{ .Name }}
+    - name: {{ replaceAll .Name "_" "-" }}
       image:
         # renovate: suite={{ .DefaultDistro }}-pgdg depName={{ replaceAll .Package "%version%" (printf "%d" .DefaultVersion) }}
         reference: ghcr.io/cloudnative-pg/{{ .Name }}:1.0-{{ .DefaultVersion }}-{{ .DefaultDistro }}
@@ -54,12 +54,12 @@ You can install `{{ .Name }}` in a specific database by creating or updating a
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: cluster-{{ .Name }}-app
+  name: cluster-{{ replaceAll .Name "_" "-" }}-app
 spec:
   name: app
   owner: app
   cluster:
-    name: cluster-{{ .Name }}
+    name: cluster-{{ replaceAll .Name "_" "-" }}
   extensions:
   - name: {{ .Name }}
     # renovate: suite={{ .DefaultDistro }}-pgdg depName={{ replaceAll .Package "%version%" (printf "%d" .DefaultVersion) }}

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -16,7 +16,7 @@ spec:
           - name: DB_URI
             valueFrom:
               secretKeyRef:
-                name: (join('-', [$values.name, 'app']))
+                name: (join('-', [$values.k8s_name, 'app']))
                 key: uri
         image: alpine/psql:latest
         command: ['sh', '-c']

--- a/test/cluster-assert.yaml
+++ b/test/cluster-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: ($values.name)
+  name: ($values.k8s_name)
 status:
   readyInstances: 1
   phase: Cluster in healthy state

--- a/test/cluster.yaml
+++ b/test/cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: ($values.name)
+  name: ($values.k8s_name)
 spec:
   imageName: ($values.pg_image)
   instances: 1
@@ -12,7 +12,7 @@ spec:
   postgresql:
     shared_preload_libraries: ($values.shared_preload_libraries)
     extensions:
-      - name: ($values.name)
+      - name: ($values.k8s_name)
         image:
           reference: ($values.extension_image)
         extension_control_path: ($values.extension_control_path)

--- a/test/database-assert.yaml
+++ b/test/database-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: (join('-', [$values.name, 'app']))
+  name: (join('-', [$values.k8s_name, 'app']))
 status:
   applied: true
   extensions:

--- a/test/database.yaml
+++ b/test/database.yaml
@@ -1,12 +1,12 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: (join('-', [$values.name, 'app']))
+  name: (join('-', [$values.k8s_name, 'app']))
 spec:
   name: app
   owner: app
   cluster:
-    name: ($values.name)
+    name: ($values.k8s_name)
   extensions:
   - name: ($values.sql_name)
     version: ($values.version)


### PR DESCRIPTION
Some extensions' name contain `_`, such as `pg_ivm`, `pg_textsearch`. Tests will fail on these extensions because this name violates k8s name's rule.

This PR fixes this by generating a `k8s_name` field in `values.yaml` and use this name as all k8s resource names.