### PR TITLE
feat: Make CREATE EXTENSION tests optional

### DIFF
--- a/dagger/maintenance/dagger.json
+++ b/dagger/maintenance/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "maintenance",
-  "engineVersion": "v0.19.10",
+  "engineVersion": "v0.19.11",
   "sdk": {
     "source": "go"
   }

--- a/dagger/maintenance/dagger.json
+++ b/dagger/maintenance/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "maintenance",
-  "engineVersion": "v0.19.7",
+  "engineVersion": "v0.19.10",
   "sdk": {
     "source": "go"
   }

--- a/dagger/maintenance/go.mod
+++ b/dagger/maintenance/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/moby/term v0.5.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
@@ -130,7 +130,7 @@ require (
 	golang.org/x/net v0.44.0 // indirect
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/text v0.29.0
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect

--- a/dagger/maintenance/go.mod
+++ b/dagger/maintenance/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/vektah/gqlparser/v2 v2.5.30
 	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
 )
 
+require go.opentelemetry.io/otel/sdk v1.38.0
+
 require (
-	github.com/99designs/gqlgen v0.17.81
+	dagger.io/dagger v0.19.11
+	github.com/99designs/gqlgen v0.17.81 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Khan/genqlient v0.8.1
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -112,30 +114,30 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0
-	go.opentelemetry.io/otel/log v0.14.0
-	go.opentelemetry.io/otel/metric v1.38.0
-	go.opentelemetry.io/otel/sdk/log v0.14.0
-	go.opentelemetry.io/otel/sdk/metric v1.38.0
-	go.opentelemetry.io/proto/otlp v1.8.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 // indirect
+	go.opentelemetry.io/otel/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/sdk/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.8.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.42.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.44.0 // indirect
-	golang.org/x/sync v0.17.0
+	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.29.0
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
-	google.golang.org/grpc v1.76.0
+	google.golang.org/grpc v1.76.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )
 

--- a/dagger/maintenance/go.sum
+++ b/dagger/maintenance/go.sum
@@ -1,3 +1,5 @@
+dagger.io/dagger v0.19.11 h1:Cra3wL1oaZsqXJcnPydocx3bIDD5tM7XCuwcn2Uh+2Q=
+dagger.io/dagger v0.19.11/go.mod h1:BjAJWl4Lx7XRW7nooNjBi0ZAC5Ici2pkthkdBIZdbTI=
 github.com/99designs/gqlgen v0.17.81 h1:kCkN/xVyRb5rEQpuwOHRTYq83i0IuTQg9vdIiwEerTs=
 github.com/99designs/gqlgen v0.17.81/go.mod h1:vgNcZlLwemsUhYim4dC1pvFP5FX0pr2Y+uYUoHFb1ig=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -185,28 +185,20 @@ func (m *Maintenance) GenerateTestingValues(
 		return nil, err
 	}
 
-	var extensionsToCreate []map[string]string
-	var expectedExtensions []map[string]any
-	if metadata.CreateExtension {
-		extensionsToCreate = []map[string]string{
-			{"name": metadata.SQLName, "version": version},
-		}
-		expectedExtensions = []map[string]any{
-			{"applied": true, "name": metadata.SQLName},
-		}
+	databaseConfig, err := generateDatabaseConfig(ctx, source, extensions)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build values.yaml content
-	values := map[string]any{
-		"name":                     metadata.Name,
-		"sql_name":                 metadata.SQLName,
-		"shared_preload_libraries": metadata.SharedPreloadLibraries,
-		"pg_image":                 pgImage,
-		"version":                  version,
-		"extensions":               extensions,
-		"create_extension":         metadata.CreateExtension,
-		"extensions_to_create":     extensionsToCreate,
-		"expected_extensions":      expectedExtensions,
+	values := TestingValues{
+		Name:                   metadata.Name,
+		SQLName:                metadata.SQLName,
+		SharedPreloadLibraries: metadata.SharedPreloadLibraries,
+		PgImage:                pgImage,
+		Version:                version,
+		Extensions:             extensions,
+		DatabaseConfig:         databaseConfig,
 	}
 	valuesYaml, err := yaml.Marshal(values)
 	if err != nil {

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -180,15 +180,17 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage)
 	}
 
-	extensions, err := generateTestingValuesExtensions(ctx, source, metadata, targetExtensionImage)
+	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, targetExtensionImage, version)
 	if err != nil {
 		return nil, err
 	}
 
-	databaseConfig, err := generateDatabaseConfig(ctx, source, extensions)
-	if err != nil {
-		return nil, err
+	extensions := make([]*ExtensionConfiguration, len(extensionInfos))
+	for i, info := range extensionInfos {
+		extensions[i] = info.Configuration
 	}
+
+	databaseConfig := generateDatabaseConfig(extensionInfos)
 
 	// Build values.yaml content
 	values := TestingValues{

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -191,6 +191,7 @@ func (m *Maintenance) GenerateTestingValues(
 	}
 
 	databaseConfig := generateDatabaseConfig(extensionInfos)
+	databaseAssertStatus := generateDatabaseAssertStatus(extensionInfos)
 
 	// Build values.yaml content
 	values := TestingValues{
@@ -202,6 +203,7 @@ func (m *Maintenance) GenerateTestingValues(
 		CreateExtension:        metadata.CreateExtension,
 		Extensions:             extensions,
 		DatabaseConfig:         databaseConfig,
+		DatabaseAssertStatus:   databaseAssertStatus,
 	}
 	valuesYaml, err := yaml.Marshal(values)
 	if err != nil {

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -185,6 +185,17 @@ func (m *Maintenance) GenerateTestingValues(
 		return nil, err
 	}
 
+	var extensionsToCreate []map[string]string
+	var expectedExtensions []map[string]any
+	if metadata.CreateExtension {
+		extensionsToCreate = []map[string]string{
+			{"name": metadata.SQLName, "version": version},
+		}
+		expectedExtensions = []map[string]any{
+			{"applied": true, "name": metadata.SQLName},
+		}
+	}
+
 	// Build values.yaml content
 	values := map[string]any{
 		"name":                     metadata.Name,
@@ -193,6 +204,9 @@ func (m *Maintenance) GenerateTestingValues(
 		"pg_image":                 pgImage,
 		"version":                  version,
 		"extensions":               extensions,
+		"create_extension":         metadata.CreateExtension,
+		"extensions_to_create":     extensionsToCreate,
+		"expected_extensions":      expectedExtensions,
 	}
 	valuesYaml, err := yaml.Marshal(values)
 	if err != nil {

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -197,6 +197,7 @@ func (m *Maintenance) GenerateTestingValues(
 		SharedPreloadLibraries: metadata.SharedPreloadLibraries,
 		PgImage:                pgImage,
 		Version:                version,
+		CreateExtension:        metadata.CreateExtension,
 		Extensions:             extensions,
 		DatabaseConfig:         databaseConfig,
 	}

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -30,6 +30,7 @@ type extensionMetadata struct {
 	LdLibraryPath          []string   `hcl:"ld_library_path" cty:"ld_library_path"`
 	AutoUpdateOsLibs       bool       `hcl:"auto_update_os_libs" cty:"auto_update_os_libs"`
 	RequiredExtensions     []string   `hcl:"required_extensions" cty:"required_extensions"`
+	CreateExtension        bool       `hcl:"create_extension" cty:"create_extension"`
 	Versions               versionMap `hcl:"versions" cty:"versions"`
 	Remain                 hcl.Body   `hcl:",remain"`
 }

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -29,6 +29,7 @@ type TestingValues struct {
 	SharedPreloadLibraries []string                  `yaml:"shared_preload_libraries"`
 	PgImage                string                    `yaml:"pg_image"`
 	Version                string                    `yaml:"version"`
+	CreateExtension        bool                      `yaml:"create_extension"`
 	Extensions             []*ExtensionConfiguration `yaml:"extensions"`
 	DatabaseConfig         *DatabaseConfig           `yaml:"database_config"`
 }

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -7,8 +7,34 @@ import (
 	"dagger/maintenance/internal/dagger"
 )
 
-func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directory, metadata *extensionMetadata, extensionImage string) ([]map[string]any, error) {
-	var out []map[string]any
+type ExtensionSpec struct {
+	Ensure  string `yaml:"ensure"`
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+type ExpectedStatus struct {
+	Applied bool   `yaml:"applied"`
+	Name    string `yaml:"name"`
+}
+
+type DatabaseConfig struct {
+	ExtensionsSpec []ExtensionSpec  `yaml:"extensions_spec"`
+	ExpectedStatus []ExpectedStatus `yaml:"expected_status"`
+}
+
+type TestingValues struct {
+	Name                   string                    `yaml:"name"`
+	SQLName                string                    `yaml:"sql_name"`
+	SharedPreloadLibraries []string                  `yaml:"shared_preload_libraries"`
+	PgImage                string                    `yaml:"pg_image"`
+	Version                string                    `yaml:"version"`
+	Extensions             []*ExtensionConfiguration `yaml:"extensions"`
+	DatabaseConfig         *DatabaseConfig           `yaml:"database_config"`
+}
+
+func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directory, metadata *extensionMetadata, extensionImage string) ([]*ExtensionConfiguration, error) {
+	var out []*ExtensionConfiguration
 	configuration, err := generateExtensionConfiguration(metadata, extensionImage)
 	if err != nil {
 		return nil, err
@@ -24,21 +50,21 @@ func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directo
 			return nil, fmt.Errorf("required dependency %q not found", dep)
 		}
 
-		depMetadata, parseErr := parseExtensionMetadata(ctx, source.Directory(dep))
-		if parseErr != nil {
-			return nil, fmt.Errorf("failed to parse dependency metadata %q: %w", dep, parseErr)
+		depMetadata, err := parseExtensionMetadata(ctx, source.Directory(dep))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse dependency metadata %q: %w", dep, err)
 		}
-		depsConfiguration, extErr := generateExtensionConfiguration(depMetadata, "")
-		if extErr != nil {
-			return nil, extErr
+		depConfiguration, err := generateExtensionConfiguration(depMetadata, "")
+		if err != nil {
+			return nil, err
 		}
-		out = append(out, depsConfiguration)
+		out = append(out, depConfiguration)
 	}
 
 	return out, nil
 }
 
-func generateExtensionConfiguration(metadata *extensionMetadata, extensionImage string) (map[string]any, error) {
+func generateExtensionConfiguration(metadata *extensionMetadata, extensionImage string) (*ExtensionConfiguration, error) {
 	targetExtensionImage := extensionImage
 	if targetExtensionImage == "" {
 		var err error
@@ -48,13 +74,56 @@ func generateExtensionConfiguration(metadata *extensionMetadata, extensionImage 
 		}
 	}
 
-	return map[string]any{
-		"name": metadata.Name,
-		"image": map[string]string{
-			"reference": targetExtensionImage,
+	return &ExtensionConfiguration{
+		Name: metadata.Name,
+		ImageVolumeSource: ImageVolumeSource{
+			Reference: targetExtensionImage,
 		},
-		"extension_control_path": metadata.ExtensionControlPath,
-		"dynamic_library_path":   metadata.DynamicLibraryPath,
-		"ld_library_path":        metadata.LdLibraryPath,
+		ExtensionControlPath: metadata.ExtensionControlPath,
+		DynamicLibraryPath:   metadata.DynamicLibraryPath,
+		LdLibraryPath:        metadata.LdLibraryPath,
 	}, nil
+}
+
+func generateDatabaseConfig(ctx context.Context, source *dagger.Directory, extensionsConfig []*ExtensionConfiguration) (*DatabaseConfig, error) {
+	var databaseConfig DatabaseConfig
+	for _, extension := range extensionsConfig {
+		extMetadata, err := parseExtensionMetadata(ctx, source.Directory(extension.Name))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse dependency metadata %q: %w", extension.Name, err)
+		}
+
+		extAnnotations, err := getImageAnnotations(extension.ImageVolumeSource.Reference)
+		if err != nil {
+			return nil, err
+		}
+
+		extVersion := extAnnotations["org.opencontainers.image.version"]
+		if extVersion == "" {
+			return nil, fmt.Errorf(
+				"extension image %s doesn't have an 'org.opencontainers.image.version' annotation",
+				extension.ImageVolumeSource.Reference)
+		}
+
+		ensureOption := "absent"
+		if extMetadata.CreateExtension {
+			ensureOption = "present"
+		}
+
+		databaseConfig.ExtensionsSpec = append(databaseConfig.ExtensionsSpec,
+			ExtensionSpec{
+				Ensure:  ensureOption,
+				Name:    extMetadata.SQLName,
+				Version: extVersion,
+			},
+		)
+		databaseConfig.ExpectedStatus = append(databaseConfig.ExpectedStatus,
+			ExpectedStatus{
+				Name:    extMetadata.SQLName,
+				Applied: true,
+			},
+		)
+	}
+
+	return &databaseConfig, nil
 }

--- a/pgaudit/metadata.hcl
+++ b/pgaudit/metadata.hcl
@@ -8,6 +8,7 @@ metadata = {
   ld_library_path          = []
   auto_update_os_libs      = false
   required_extensions      = []
+  create_extension         = true
 
   versions = {
     bookworm = {

--- a/pgvector/metadata.hcl
+++ b/pgvector/metadata.hcl
@@ -8,6 +8,7 @@ metadata = {
   ld_library_path          = []
   auto_update_os_libs      = false
   required_extensions      = []
+  create_extension         = true
 
   versions = {
     bookworm = {

--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -8,6 +8,7 @@ metadata = {
   ld_library_path          = ["system"]
   auto_update_os_libs      = true
   required_extensions      = []
+  create_extension         = true
 
   versions = {
     bookworm = {

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -47,6 +47,7 @@ metadata = {
   # `required_extensions`: must contain the name(s) of the sibling
   # folders in this repository that contain a required extension.
   required_extensions      = []
+  create_extension         = true
 
   versions = {
     {{- range $distro := .Distros}}

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -47,6 +47,12 @@ metadata = {
   # `required_extensions`: must contain the name(s) of the sibling
   # folders in this repository that contain a required extension.
   required_extensions      = []
+
+  # TODO: Remove this comment block after customizing the file.
+  # `create_extension`: if set to `true` (default), the test suite will
+  # automatically run `CREATE EXTENSION` for this project during E2E tests.
+  # Set to `false` if the image only provides libraries or tools without
+  # a formal Postgres extension object.
   create_extension         = true
 
   versions = {

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -13,6 +13,8 @@ spec:
             value: ($values.sql_name)
           - name: EXT_VERSION
             value: ($values.version)
+          - name: CREATE_EXTENSION
+            value: (to_string($values.create_extension))
           - name: DB_URI
             valueFrom:
               secretKeyRef:
@@ -23,6 +25,10 @@ spec:
         args:
          - |
            set -e
+           if [ "$CREATE_EXTENSION" != "true" ]; then
+             echo "Skipping extension check (create_extension=false)"
+             exit 0
+           fi
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|")
            test "$(psql "$DB_URI" -tAc "SELECT EXISTS (SELECT FROM pg_catalog.pg_extension WHERE extname = '${EXT_SQL_NAME}' AND extversion = '${EXT_VERSION}')" -q)" = "t"
            echo "Extension '${EXT_SQL_NAME} v${EXT_VERSION}' is installed!"

--- a/test/database-assert.yaml
+++ b/test/database-assert.yaml
@@ -2,7 +2,4 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
   name: (join('-', [$values.name, 'app']))
-status:
-  applied: true
-  extensions: ($values.database_config.expected_status)
-  observedGeneration: 1
+status: ($values.database_assert_status)

--- a/test/database-assert.yaml
+++ b/test/database-assert.yaml
@@ -4,3 +4,5 @@ metadata:
   name: (join('-', [$values.name, 'app']))
 status:
   applied: true
+  extensions: ($values.database_config.expected_status)
+  observedGeneration: 1

--- a/test/database-assert.yaml
+++ b/test/database-assert.yaml
@@ -4,7 +4,3 @@ metadata:
   name: (join('-', [$values.name, 'app']))
 status:
   applied: true
-  extensions:
-  - applied: true
-    name: ($values.sql_name)
-  observedGeneration: 1

--- a/test/database.yaml
+++ b/test/database.yaml
@@ -7,4 +7,4 @@ spec:
   owner: app
   cluster:
     name: ($values.name)
-  extensions: ($values.extensions_to_create)
+  extensions: ($values.database_config.extensions_spec)

--- a/test/database.yaml
+++ b/test/database.yaml
@@ -7,6 +7,4 @@ spec:
   owner: app
   cluster:
     name: ($values.name)
-  extensions:
-  - name: ($values.sql_name)
-    version: ($values.version)
+  extensions: ($values.extensions_to_create)


### PR DESCRIPTION
Adds a `create_extension` boolean field to extension metadata so that extensions providing only libraries or tools (e.g. wal2json) can skip `CREATE EXTENSION` tests. When `create_extension` is `false`, the extension is omitted entirely from the Database CR's `extensions_spec` and the status assertion skips the `extensions` field.

The generated `database_assert_status` map conditionally includes or excludes the `extensions` key, avoiding the Chainsaw limitation where `extensions: null` would require the field to exist in the actual resource. The psql verification job in `check-extension.yaml` also reads `create_extension` and skips when false.

Example generated values for `create_extension: true` (pgvector):

```yaml
name: pgvector
sql_name: vector
shared_preload_libraries: []
pg_image: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
version: 0.8.1
create_extension: true
extensions:
    - name: pgvector
      image:
        reference: registry.pg-extensions:5000/pgvector-testing:0.8.1-18-trixie
database_config:
    extensions_spec:
        - ensure: present
          name: vector
          version: 0.8.1
database_assert_status:
    applied: true
    observedGeneration: 1
    extensions:
        - applied: true
          name: vector
```

Example generated values for `create_extension: false` (wal2json):

```yaml
name: wal2json
sql_name: wal2json
shared_preload_libraries: []
pg_image: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
version: 2.6
create_extension: false
extensions:
    - name: wal2json
      image:
        reference: registry.pg-extensions:5000/wal2json-testing:2.6-18-trixie
database_config: {}
database_assert_status:
    applied: true
    observedGeneration: 1
```

Closes #85 