### PR TITLE
feat: generate extension catalogs

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -89,3 +89,16 @@ jobs:
       extension_name: ${{ matrix.extension }}
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  Catalogs:
+    name: Update Catalogs
+    needs: Bake
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+        with:
+          event-type: update-catalogs

--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -1,4 +1,4 @@
-name: Update Catalogs
+name: Update Extension Image Catalogs
 
 on:
   schedule:

--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -1,6 +1,9 @@
 name: Update Catalogs
 
 on:
+  schedule:
+    # Refresh Catalogs once a week, on Mondays - 1h after postgres-container images
+    - cron: 0 9 * * 1
   workflow_dispatch:
   repository_dispatch:
     types: [update-catalogs]

--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -1,0 +1,57 @@
+name: Update Catalogs
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [update-catalogs]
+
+permissions: read-all
+
+defaults:
+  run:
+    shell: "bash -Eeuo pipefail -x {0}"
+
+jobs:
+  update-catalogs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Checkout artifacts
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          path: artifacts
+          repository: cloudnative-pg/artifacts
+          token: ${{ secrets.REPO_GHA_PAT }}
+          ref: main
+
+      - name: Update catalogs
+        id: update-extension-catalogs
+        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644 # v8.2.0
+        env:
+          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+          DAGGER_VERSION: 0.19.10
+        with:
+          version: ${{ env.DAGGER_VERSION }}
+          verb: call
+          module: ./dagger/maintenance/
+          args: generate-catalogs --catalogs-dir artifacts/image-catalogs/ export --path artifacts/image-catalogs/
+
+      - name: Diff
+        working-directory: artifacts
+        run: |
+          git add -A .
+          git status
+          git diff --staged
+
+      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
+        if: github.ref == 'refs/heads/main'
+        with:
+          cwd: 'artifacts'
+          add: 'image-catalogs'
+          author_name: CloudNativePG Automated Updates
+          author_email: noreply@cnpg.com
+          message: 'chore: update extensions imageCatalogs'

--- a/README.md
+++ b/README.md
@@ -161,9 +161,6 @@ skopeo inspect docker://<image> | jq '.Labels'
 
 ## Image catalogs
 
-
-## Image catalogs
-
 To simplify the deployment of PostgreSQL extensions, this project automatically
 generates `ClusterImageCatalog` resources. These catalogs provide a curated
 list of compatible extension images for PostgreSQL 18+ versions.

--- a/README.md
+++ b/README.md
@@ -158,3 +158,19 @@ docker buildx imagetools inspect <image> --raw | jq '.annotations'
 # Using skopeo
 skopeo inspect docker://<image> | jq '.Labels'
 ```
+
+## Image catalogs
+
+
+## Image catalogs
+
+To simplify the deployment of PostgreSQL extensions, this project automatically
+generates `ClusterImageCatalog` resources. These catalogs provide a curated
+list of compatible extension images for PostgreSQL 18+ versions.
+
+- **Frequency:** Built once a week.
+- **Location:** Published in the [`artifacts`
+  project](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs).
+- **Naming Convention:** These are based on the `minimal` catalog and use the
+  `catalog-extensions` prefix (e.g., `catalog-extensions-trixie.yaml`).
+

--- a/dagger/maintenance/catalogs.go
+++ b/dagger/maintenance/catalogs.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+
+	"go.yaml.in/yaml/v3"
+
+	"dagger/maintenance/internal/dagger"
+)
+
+const (
+	LabelImageOS   = "images.cnpg.io/os"
+	LabelImageType = "images.cnpg.io/type"
+)
+
+type ImageVolumeSource struct {
+	Reference  string `yaml:"reference"`
+	PullPolicy string `yaml:"pullPolicy,omitempty"`
+}
+
+type ExtensionConfiguration struct {
+	Name                 string            `yaml:"name"`
+	ImageVolumeSource    ImageVolumeSource `yaml:"image"`
+	ExtensionControlPath []string          `yaml:"extensionControlPath,omitempty"`
+	DynamicLibraryPath   []string          `yaml:"dynamicLibraryPath,omitempty"`
+	LdLibraryPath        []string          `yaml:"ldLibraryPath,omitempty"`
+}
+
+type ImageCatalog struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name   string            `yaml:"name"`
+		Labels map[string]string `yaml:"labels"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Images []struct {
+			Major      int                      `yaml:"major"`
+			Image      string                   `yaml:"image"`
+			Extensions []ExtensionConfiguration `yaml:"extensions,omitempty"`
+		} `yaml:"images"`
+	} `yaml:"spec"`
+}
+
+func getMinimalCatalogs(ctx context.Context, catalogsDir *dagger.Directory) ([]*ImageCatalog, error) {
+	entries, err := catalogsDir.Entries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var catalogs []*ImageCatalog
+
+	for _, entry := range entries {
+		if ext := filepath.Ext(entry); ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		content, err := catalogsDir.File(entry).Contents(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("while retrieving %s: %w", entry, err)
+		}
+
+		var catalog ImageCatalog
+		if err := yaml.Unmarshal([]byte(content), &catalog); err != nil {
+			return nil, fmt.Errorf("while decoding %s: %w", entry, err)
+		}
+
+		// Only keep ClusterImageCatalogs
+		if catalog.Kind != "ClusterImageCatalog" {
+			continue
+		}
+
+		// Only keep catalogs with minimal images
+		if catalog.Metadata.Labels[LabelImageType] != "minimal" {
+			continue
+		}
+
+		// Only keep catalogs for Supported Distros
+		catalogOS, ok := catalog.Metadata.Labels[LabelImageOS]
+		if !ok {
+			return nil, fmt.Errorf("while retrieving OS for %q catalog", entry)
+		}
+		if !slices.Contains(SupportedDistributions, catalogOS) {
+			continue
+		}
+
+		catalogs = append(catalogs, &catalog)
+	}
+
+	return catalogs, nil
+}
+
+func writeCatalogToDir(catalog *ImageCatalog, outDir *dagger.Directory) (*dagger.Directory, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	if err := enc.Encode(catalog); err != nil {
+		return nil, fmt.Errorf("while encoding catalog %s: %w", catalog.Metadata.Name, err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+
+	outName := fmt.Sprintf("catalog-extensions-%s.yaml", catalog.Metadata.Labels[LabelImageOS])
+
+	return outDir.WithNewFile(outName, buf.String()), nil
+}

--- a/dagger/maintenance/catalogs.go
+++ b/dagger/maintenance/catalogs.go
@@ -25,9 +25,9 @@ type ImageVolumeSource struct {
 type ExtensionConfiguration struct {
 	Name                 string            `yaml:"name"`
 	ImageVolumeSource    ImageVolumeSource `yaml:"image"`
-	ExtensionControlPath []string          `yaml:"extensionControlPath,omitempty"`
-	DynamicLibraryPath   []string          `yaml:"dynamicLibraryPath,omitempty"`
-	LdLibraryPath        []string          `yaml:"ldLibraryPath,omitempty"`
+	ExtensionControlPath []string          `yaml:"extension_control_path,omitempty"`
+	DynamicLibraryPath   []string          `yaml:"dynamic_library_path,omitempty"`
+	LdLibraryPath        []string          `yaml:"ld_library_path,omitempty"`
 }
 
 type ImageCatalog struct {

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	containerregistryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -59,10 +60,61 @@ func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {
 	return getExtensionImage(metadata, DefaultDistribution, DefaultPgMajor)
 }
 
-// getExtensionImage returns the extension image for a given distribution and pgMajor,
-// resolved from the metadata.
+// getExtensionImage returns the extension image for a given distribution and pgMajor.
 func getExtensionImage(metadata *extensionMetadata, distribution string, pgMajor int) (string, error) {
-	packageVersion := metadata.Versions[distribution][strconv.Itoa(pgMajor)]
+	version, err := extractExtensionVersion(metadata.Versions, distribution, pgMajor)
+	if err != nil {
+		return "", fmt.Errorf("while extracting extension version for %s: %w", metadata.Name, err)
+	}
+
+	image := fmt.Sprintf("ghcr.io/cloudnative-pg/%s:%s-%d-%s",
+		metadata.ImageName, version, pgMajor, distribution)
+
+	return image, nil
+}
+
+// getExtensionImageWithTimestamp returns the extension image with the latest timestamp
+// for a given distribution and pgMajor.
+func getExtensionImageWithTimestamp(metadata *extensionMetadata, distribution string, pgMajor int) (string, error) {
+	imageName := fmt.Sprintf("ghcr.io/cloudnative-pg/%s", metadata.ImageName)
+	tags, err := crane.ListTags(imageName)
+	if err != nil {
+		return "", fmt.Errorf("while listing tags for image %s: %w", imageName, err)
+	}
+
+	version, err := extractExtensionVersion(metadata.Versions, distribution, pgMajor)
+	if err != nil {
+		return "", fmt.Errorf("while extracting extension version for %s: %w", metadata.Name, err)
+	}
+
+	re := regexp.MustCompile(
+		fmt.Sprintf(`^%s-(\d{12})-%d-%s$`,
+			regexp.QuoteMeta(version),
+			pgMajor,
+			distribution,
+		),
+	)
+
+	var latestTag string
+	for _, tag := range tags {
+		if re.MatchString(tag) && tag > latestTag {
+			latestTag = tag
+		}
+	}
+	if latestTag == "" {
+		return "", fmt.Errorf(
+			"no image found for image %s (version=%s pgMajor=%d os=%s",
+			imageName, version, pgMajor, distribution,
+		)
+	}
+
+	return fmt.Sprintf("%s:%s", imageName, latestTag), nil
+}
+
+// extractExtensionVersion returns the extension version for a given distribution and pgMajor,
+// extracted from the extension's metadata.
+func extractExtensionVersion(versions versionMap, distribution string, pgMajor int) (string, error) {
+	packageVersion := versions[distribution][strconv.Itoa(pgMajor)]
 	if packageVersion == "" {
 		return "", fmt.Errorf("no package version found for distribution %q and version %d",
 			distribution, pgMajor)
@@ -73,9 +125,6 @@ func getExtensionImage(metadata *extensionMetadata, distribution string, pgMajor
 	if len(matches) < 2 {
 		return "", fmt.Errorf("cannot extract extension version from %q", packageVersion)
 	}
-	version := matches[1]
-	image := fmt.Sprintf("ghcr.io/cloudnative-pg/%s:%s-%d-%s",
-		metadata.ImageName, version, pgMajor, distribution)
 
-	return image, nil
+	return matches[1], nil
 }

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -108,7 +108,19 @@ func getExtensionImageWithTimestamp(metadata *extensionMetadata, distribution st
 		)
 	}
 
-	return fmt.Sprintf("%s:%s", imageName, latestTag), nil
+	imageRef := fmt.Sprintf("%s:%s", imageName, latestTag)
+
+	ref, err := name.ParseReference(imageRef, name.Insecure)
+	if err != nil {
+		return "", fmt.Errorf("while parsing image reference %s: %w", imageRef, err)
+	}
+
+	desc, err := remote.Get(ref)
+	if err != nil {
+		return "", fmt.Errorf("while fetching digest for image %s: %w", imageRef, err)
+	}
+
+	return fmt.Sprintf("%s@%s", imageRef, desc.Digest.String()), nil
 }
 
 // extractExtensionVersion returns the extension version for a given distribution and pgMajor,

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -103,7 +103,7 @@ func getExtensionImageWithTimestamp(metadata *extensionMetadata, distribution st
 	}
 	if latestTag == "" {
 		return "", fmt.Errorf(
-			"no image found for image %s (version=%s pgMajor=%d os=%s",
+			"no image found for image %s (version=%s pgMajor=%d os=%s)",
 			imageName, version, pgMajor, distribution,
 		)
 	}

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -17,6 +17,11 @@ const (
 	DefaultDistribution = "trixie"
 )
 
+var SupportedDistributions = []string{
+	"bookworm",
+	"trixie",
+}
+
 // getImageAnnotations returns the OCI annotations given an image ref.
 func getImageAnnotations(imageRef string) (map[string]string, error) {
 	// Setting Insecure option to allow fetching images from local registries with no TLS
@@ -51,10 +56,16 @@ func getImageAnnotations(imageRef string) (map[string]string, error) {
 // getDefaultExtensionImage returns the default extension image for a given extension,
 // resolved from the metadata.
 func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {
-	packageVersion := metadata.Versions[DefaultDistribution][strconv.Itoa(DefaultPgMajor)]
+	return getExtensionImage(metadata, DefaultDistribution, DefaultPgMajor)
+}
+
+// getExtensionImage returns the extension image for a given distribution and pgMajor,
+// resolved from the metadata.
+func getExtensionImage(metadata *extensionMetadata, distribution string, pgMajor int) (string, error) {
+	packageVersion := metadata.Versions[distribution][strconv.Itoa(pgMajor)]
 	if packageVersion == "" {
 		return "", fmt.Errorf("no package version found for distribution %q and version %d",
-			DefaultDistribution, DefaultPgMajor)
+			distribution, pgMajor)
 	}
 
 	re := regexp.MustCompile(`^(\d+(?:\.\d+)+)`)
@@ -64,7 +75,7 @@ func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {
 	}
 	version := matches[1]
 	image := fmt.Sprintf("ghcr.io/cloudnative-pg/%s:%s-%d-%s",
-		metadata.ImageName, version, DefaultPgMajor, DefaultDistribution)
+		metadata.ImageName, version, pgMajor, distribution)
 
 	return image, nil
 }

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -455,15 +455,15 @@ func (m *Maintenance) GenerateCatalogs(
 				continue
 			}
 
+			metadata, err := parseExtensionMetadata(ctx, source.Directory(dir))
+			if err != nil {
+				return nil, fmt.Errorf("while parsing extension %s metadata: %w", extension, err)
+			}
+
 			for i := range catalog.Spec.Images {
 				img := &catalog.Spec.Images[i]
 				if !slices.Contains(matrix.MajorVersions, strconv.Itoa(img.Major)) {
 					continue
-				}
-
-				metadata, err := parseExtensionMetadata(ctx, source.Directory(dir))
-				if err != nil {
-					return nil, fmt.Errorf("while parsing extension %s metadata: %w", extension, err)
 				}
 
 				targetExtensionImage, err := getExtensionImageWithTimestamp(metadata, catalogOS, img.Major)

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -466,7 +466,7 @@ func (m *Maintenance) GenerateCatalogs(
 					return nil, fmt.Errorf("while parsing extension %s metadata: %w", extension, err)
 				}
 
-				targetExtensionImage, err := getExtensionImage(metadata, catalogOS, img.Major)
+				targetExtensionImage, err := getExtensionImageWithTimestamp(metadata, catalogOS, img.Major)
 				if err != nil {
 					return nil, fmt.Errorf("while retrieving extension %s image: %w", extension, err)
 				}


### PR DESCRIPTION
Closes https://github.com/cloudnative-pg/artifacts/issues/7

Add a new dagger command to generate extensions catalog (e.g ClusterImageCatalogs with extensions)
starting from a base set of `minimal` catalogs, like the ones currently in https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs.

Add a new GH workflow that, at the end of every successful build on `main`, triggers an update of the catalogs which will be uploaded inside the `image-catalogs` directory of [cloudnative-pg/artifacts](https://github.com/cloudnative-pg/artifacts).