### PR TITLE
chore: add digest

### DIFF
--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -108,7 +108,19 @@ func getExtensionImageWithTimestamp(metadata *extensionMetadata, distribution st
 		)
 	}
 
-	return fmt.Sprintf("%s:%s", imageName, latestTag), nil
+	imageRef := fmt.Sprintf("%s:%s", imageName, latestTag)
+
+	ref, err := name.ParseReference(imageRef, name.Insecure)
+	if err != nil {
+		return "", fmt.Errorf("while parsing image reference %s: %w", imageRef, err)
+	}
+
+	desc, err := remote.Get(ref)
+	if err != nil {
+		return "", fmt.Errorf("while fetching digest for image %s: %w", imageRef, err)
+	}
+
+	return fmt.Sprintf("%s@%s", imageRef, desc.Digest.String()), nil
 }
 
 // extractExtensionVersion returns the extension version for a given distribution and pgMajor,


### PR DESCRIPTION

add digests to extension image references


Sample catalog

```yaml
    - major: 18
      image: ghcr.io/cloudnative-pg/postgresql:18.1-202602020815-minimal-bookworm@sha256:117fdbfbffafa0e77c79732a3820e08079c9cdf557358bee32c20497acf07f1f
      extensions:
        - name: pgaudit
          image:
            reference: ghcr.io/cloudnative-pg/pgaudit:18.0-202602041054-18-bookworm@sha256:d7658fd4ae929af3fe0f6dcf4c6d2741873ea7ec71afdcfeaa67325b1e5c3924
        - name: pgvector
          image:
            reference: ghcr.io/cloudnative-pg/pgvector:0.8.1-202602041054-18-bookworm@sha256:02673de161dcba4bf4a462e8a3954191ebc41043b32f700eea1910bdc2febe0a
        - name: postgis
          image:
            reference: ghcr.io/cloudnative-pg/postgis-extension:3.6.1-202602041054-18-bookworm@sha256:a51fe6f0448e07941d8da6b157f56c02d73a50b07a4f205fac6c440b7746cde2
          ld_library_path:
            - /system

```