### PR TITLE
Add pg-jsonschema extension target

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ they are maintained by their respective authors, and PostgreSQL Debian Group
 | :--- | :--- | :--- |
 | **[pgAudit](pgaudit)** | PostgreSQL audit extension | [github.com/pgaudit/pgaudit](https://github.com/pgaudit/pgaudit) |
 | **[pg_crash](pg-crash)** | **Disruptive** fault injection and chaos engineering extension | [github.com/cybertec-postgresql/pg_crash](https://github.com/cybertec-postgresql/pg_crash) |
+| **[pg_jsonschema](pg-jsonschema)** | JSON Schema validation for PostgreSQL `json` and `jsonb` data | [github.com/supabase/pg_jsonschema](https://github.com/supabase/pg_jsonschema) |
 | **[pgvector](pgvector)** | Vector similarity search for PostgreSQL | [github.com/pgvector/pgvector](https://github.com/pgvector/pgvector) |
 | **[PostGIS](postgis)** | Geospatial database extension for PostgreSQL | [postgis.net/](https://postgis.net/) |
 
@@ -181,4 +182,3 @@ list of compatible extension images for PostgreSQL 18+ versions.
   project](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs-extensions).
 - **Naming Convention:** These are based on the `minimal` catalog and use the
   `catalog-minimal` prefix (e.g., `catalog-minimal-trixie.yaml`).
-

--- a/pg-jsonschema/Dockerfile
+++ b/pg-jsonschema/Dockerfile
@@ -1,0 +1,41 @@
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+FROM $BASE AS builder
+
+ARG PG_MAJOR
+ARG EXT_VERSION
+ARG TARGETARCH
+
+USER 0
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) arch="amd64" ;; \
+        arm64) arch="arm64" ;; \
+        *) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/pg_jsonschema.deb \
+        "https://github.com/supabase/pg_jsonschema/releases/download/v${EXT_VERSION}/pg_jsonschema-v${EXT_VERSION}-pg${PG_MAJOR}-${arch}-linux-gnu.deb"; \
+    dpkg -i /tmp/pg_jsonschema.deb; \
+    rm /tmp/pg_jsonschema.deb; \
+    curl -fsSL -o /licenses/pg_jsonschema/LICENSE \
+        --create-dirs \
+        "https://raw.githubusercontent.com/supabase/pg_jsonschema/v${EXT_VERSION}/LICENSE"
+
+FROM scratch
+ARG PG_MAJOR
+
+# Licenses
+COPY --from=builder /licenses /licenses/
+
+# Libraries
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/pg_jsonschema.so /lib/
+
+# Share
+COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/pg_jsonschema* /share/extension/
+
+USER 65532:65532

--- a/pg-jsonschema/README.md
+++ b/pg-jsonschema/README.md
@@ -1,0 +1,65 @@
+# pg_jsonschema
+
+[pg_jsonschema](https://github.com/supabase/pg_jsonschema) is a PostgreSQL
+extension that adds JSON Schema validation for `json` and `jsonb` data.
+
+This image provides a convenient way to deploy and manage `pg_jsonschema` with
+[CloudNativePG](https://cloudnative-pg.io/).
+
+## Usage
+
+### 1. Add the extension image to your Cluster
+
+Define the `pg-jsonschema` extension under the `postgresql.extensions` section
+of your `Cluster` resource. For example:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pg-jsonschema
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    extensions:
+    - name: pg-jsonschema
+      image:
+        # renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+        reference: ghcr.io/cloudnative-pg/pg-jsonschema:0.3.4-18-trixie
+```
+
+### 2. Enable the extension in a database
+
+Create or update a `Database` resource to install the extension in a specific
+database:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: cluster-pg-jsonschema-app
+spec:
+  name: app
+  owner: app
+  cluster:
+    name: cluster-pg-jsonschema
+  extensions:
+  - name: pg_jsonschema
+    # renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+    version: "0.3.4"
+```
+
+### 3. Verify installation
+
+Once the database is ready, connect to it with `psql` and run:
+
+```sql
+\dx
+```
+
+You should see `pg_jsonschema` listed among the installed extensions.

--- a/pg-jsonschema/metadata.hcl
+++ b/pg-jsonschema/metadata.hcl
@@ -1,0 +1,22 @@
+metadata = {
+  name                     = "pg-jsonschema"
+  sql_name                 = "pg_jsonschema"
+  image_name               = "pg-jsonschema"
+  shared_preload_libraries = []
+  extension_control_path   = []
+  dynamic_library_path     = []
+  ld_library_path          = []
+  auto_update_os_libs      = false
+  required_extensions      = []
+
+  versions = {
+    bookworm = {
+      // renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+      "18" = "0.3.4"
+    }
+    trixie = {
+      // renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+      "18" = "0.3.4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `pg-jsonschema` extension target
- add build recipe in `pg-jsonschema/Dockerfile` to compile and install `pg_jsonschema` from upstream release tags
- add extension metadata in `pg-jsonschema/metadata.hcl` for PostgreSQL 18 on `bookworm` and `trixie`
- add usage documentation in `pg-jsonschema/README.md`
- add `pg-jsonschema` to the supported extensions table in `README.md`

## Notes
- this target currently builds from upstream source tags (Supabase `pg_jsonschema`) rather than a PGDG package.

## Validation
- `docker buildx bake -f pg-jsonschema/metadata.hcl -f docker-bake.hcl --check`
