### PR TITLE
fix: reduce number of licenses in PostGIS

### DIFF
--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -2,14 +2,8 @@ metadata = {
   name                     = "postgis"
   sql_name                 = "postgis"
   image_name               = "postgis-extension"
-  licenses                 = [ "Apache-2.0", "blessing", "BSD-2-Clause", "BSD-3-Clause",
-                              "BSD-3-Clause-Clear", "BSD-3-Clause-LBNL", "BSD-4-Clause-UC",
-                              "BSL-1.0", "CC-BY-3.0", "CC-BY-4.0", "CC-BY-SA-3.0", "curl",
-                              "FTL", "GPL-2.0-or-later", "GPL-3.0-or-later", "HDF5", "HPND-sell-variant",
-                              "IJG", "Info-ZIP", "ISC", "LGPL-2.1-or-later", "Libpng", "libtiff",
-                              "MIT", "MIT-Modern-Variant", "MPL-1.1", "OLDAP-2.8",
-                              "PostgreSQL", "Spencer-86", "SPL-1.0", "Unicode-DFS-2015",
-                              "Unlicense", "X11", "Zlib" ]
+  licenses                 = [ "GPL-2.0-or-later", "MIT", "LGPL-2.1-or-later",
+                               "GPL-3.0-or-later", "Apache-2.0", "PostgreSQL", "Zlib" ]
   shared_preload_libraries = []
   extension_control_path   = []
   dynamic_library_path     = []

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -10,12 +10,13 @@ metadata = {
   image_name               = "{{ .Name }}"
 
   # TODO: Remove this comment block after customizing the file.
-  # `licenses`: A list of SPDX identifiers representing the software's licenses.
+  # `licenses`: A list of SPDX identifiers representing the main software's licenses.
   # Formatting Rules:
   # - Must be a list of strings: ["MIT", "Apache-2.0"]
   # - Use SPDX IDs exactly as they appear at https://spdx.org/licenses/
   # - These are automatically joined with " AND " to populate the OCI label
   #   org.opencontainers.image.licenses
+  # Warning: the ghcr.io registry requires labels < 256 characters
   # Examples: "Apache-2.0", "PostgreSQL", "MIT".
   licenses                 = ["Apache-2.0"]
 


### PR DESCRIPTION
Due to an apparent hard limit of 256 characters in ghcr.io for labels, we have rescoped the labels annotation to just cover the main licenses of the image.

Closes #115