### PR TITLE
fix(security): harden GitHub Actions workflows against expression injection

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -61,8 +61,9 @@ jobs:
           CHANGES: ${{ steps.filter.outputs.changes }}
           # Input Extension name
           INPUT_EXTENSION_NAME: ${{ github.event.inputs.extension_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          if [[ "${EVENT_NAME}" == 'workflow_dispatch' ]]; then
             CHANGES="[\"$INPUT_EXTENSION_NAME\"]"
           fi
 

--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -141,15 +141,20 @@ jobs:
           task e2e:setup-env
 
       - name: Generate Chainsaw testing values
+        env:
+          MATRIX_IMAGE: ${{ matrix.image }}
+          EXTENSION_NAME: ${{ inputs.extension_name }}
         run: |
-          task e2e:generate-values EXTENSION_IMAGE="${{ matrix.image }}" TARGET="${{ inputs.extension_name }}"
+          task e2e:generate-values EXTENSION_IMAGE="${MATRIX_IMAGE}" TARGET="${EXTENSION_NAME}"
 
       - name: Run e2e tests
+        env:
+          EXTENSION_NAME: ${{ inputs.extension_name }}
         run: |
           # Get Kind cluster internal kubeconfig
           task e2e:export-kubeconfig KUBECONFIG_PATH=./kubeconfig INTERNAL=true
 
-          task e2e:test TARGET="${{ inputs.extension_name }}" KUBECONFIG_PATH="./kubeconfig"
+          task e2e:test TARGET="${EXTENSION_NAME}" KUBECONFIG_PATH="./kubeconfig"
 
   copytoproduction:
     name: Copy images to production

--- a/.github/workflows/update_os_libraries.yml
+++ b/.github/workflows/update_os_libraries.yml
@@ -37,8 +37,10 @@ jobs:
 
       - name: Set extensions output
         id: get-extensions
+        env:
+          EXTENSIONS_OUTPUT: ${{ steps.get-extensions-dagger.outputs.output }}
         run: |
-          EXTENSIONS='${{ steps.get-extensions-dagger.outputs.output }}'
+          EXTENSIONS="${EXTENSIONS_OUTPUT}"
           echo "extensions=$(echo "$EXTENSIONS" | jq -c .)" >> $GITHUB_OUTPUT
 
   update-extension-os-libs:


### PR DESCRIPTION
Move `${{ }}` expressions from `run:` blocks into step-level `env:` blocks, then reference them as properly-quoted shell variables.

Part of cloudnative-pg/cloudnative-pg#10113

Assisted-by: Claude Opus 4.6