### PR TITLE
ci: update extension catalogs output dir

### DIFF
--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -44,7 +44,7 @@ jobs:
           version: ${{ env.DAGGER_VERSION }}
           verb: call
           module: ./dagger/maintenance/
-          args: generate-catalogs --catalogs-dir artifacts/image-catalogs/ export --path artifacts/image-catalogs/extensions/
+          args: generate-catalogs --catalogs-dir artifacts/image-catalogs/ export --path artifacts/image-catalogs-extensions/
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
@@ -67,7 +67,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           cwd: 'artifacts'
-          add: 'image-catalogs'
+          add: 'image-catalogs-extensions'
           author_name: CloudNativePG Automated Updates
           author_email: noreply@cnpg.com
           message: 'chore: update extensions imageCatalogs'

--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Sign catalogs
         run: |
-          for file in artifacts/image-catalogs/*.yaml; do
+          for file in artifacts/image-catalogs-extensions/*.yaml; do
               echo "Signing $file..."
               cosign sign-blob "$file" --bundle "$file.sigstore.json" --yes
           done

--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -44,7 +44,7 @@ jobs:
           version: ${{ env.DAGGER_VERSION }}
           verb: call
           module: ./dagger/maintenance/
-          args: generate-catalogs --catalogs-dir artifacts/image-catalogs/ export --path artifacts/image-catalogs/
+          args: generate-catalogs --catalogs-dir artifacts/image-catalogs/ export --path artifacts/image-catalogs/extensions/
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ list of compatible extension images for PostgreSQL 18+ versions.
 
 - **Frequency:** Built once a week.
 - **Location:** Published in the [`artifacts`
-  project](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs).
+  project](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs-extensions).
 - **Naming Convention:** These are based on the `minimal` catalog and use the
   `catalog-minimal` prefix (e.g., `catalog-minimal-trixie.yaml`).
 

--- a/README.md
+++ b/README.md
@@ -178,5 +178,5 @@ list of compatible extension images for PostgreSQL 18+ versions.
 - **Location:** Published in the [`artifacts`
   project](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs).
 - **Naming Convention:** These are based on the `minimal` catalog and use the
-  `catalog-extensions` prefix (e.g., `catalog-extensions-trixie.yaml`).
+  `catalog-minimal` prefix (e.g., `catalog-minimal-trixie.yaml`).
 

--- a/dagger/maintenance/catalogs.go
+++ b/dagger/maintenance/catalogs.go
@@ -106,7 +106,7 @@ func writeCatalogToDir(catalog *ImageCatalog, outDir *dagger.Directory) (*dagger
 		return nil, err
 	}
 
-	outName := fmt.Sprintf("catalog-extensions-%s.yaml", catalog.Metadata.Labels[LabelImageOS])
+	outName := fmt.Sprintf("catalog-minimal-%s.yaml", catalog.Metadata.Labels[LabelImageOS])
 
 	return outDir.WithNewFile(outName, buf.String()), nil
 }


### PR DESCRIPTION
Updates the pipeline to output extension image catalogs to the `artifacts/image-catalogs-extensions/` directory instead of writing them into the input `artifacts/image-catalogs/` directory. Renames the file prefix from `catalog-extensions-*` to `catalog-minimal-*` and fixes cosign signing to target the new output directory.

Closes #133 