### PR TITLE
feat: add `bin_path` support in image catalogs

### DIFF
--- a/dagger/maintenance/catalogs.go
+++ b/dagger/maintenance/catalogs.go
@@ -28,6 +28,7 @@ type ExtensionConfiguration struct {
 	ExtensionControlPath []string          `yaml:"extension_control_path,omitempty"`
 	DynamicLibraryPath   []string          `yaml:"dynamic_library_path,omitempty"`
 	LdLibraryPath        []string          `yaml:"ld_library_path,omitempty"`
+	BinPath              []string          `yaml:"bin_path,omitempty"`
 }
 
 type ImageCatalog struct {

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -514,6 +514,7 @@ func (m *Maintenance) GenerateCatalogs(
 					ExtensionControlPath: metadata.ExtensionControlPath,
 					DynamicLibraryPath:   metadata.DynamicLibraryPath,
 					LdLibraryPath:        metadata.LdLibraryPath,
+					BinPath:              metadata.BinPath,
 				}
 
 				img.Extensions = append(img.Extensions, extensionsConfig)

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -28,6 +28,7 @@ type extensionMetadata struct {
 	ExtensionControlPath   []string   `hcl:"extension_control_path" cty:"extension_control_path"`
 	DynamicLibraryPath     []string   `hcl:"dynamic_library_path" cty:"dynamic_library_path"`
 	LdLibraryPath          []string   `hcl:"ld_library_path" cty:"ld_library_path"`
+	BinPath                []string   `hcl:"bin_path" cty:"bin_path"`
 	AutoUpdateOsLibs       bool       `hcl:"auto_update_os_libs" cty:"auto_update_os_libs"`
 	RequiredExtensions     []string   `hcl:"required_extensions" cty:"required_extensions"`
 	CreateExtension        bool       `hcl:"create_extension" cty:"create_extension"`

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -108,6 +108,7 @@ func generateExtensionConfiguration(metadata *extensionMetadata, extensionImage 
 		ExtensionControlPath: metadata.ExtensionControlPath,
 		DynamicLibraryPath:   metadata.DynamicLibraryPath,
 		LdLibraryPath:        metadata.LdLibraryPath,
+		BinPath:              metadata.BinPath,
 	}, nil
 }
 

--- a/pgaudit/metadata.hcl
+++ b/pgaudit/metadata.hcl
@@ -7,6 +7,7 @@ metadata = {
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = []
+  bin_path                 = []
   auto_update_os_libs      = false
   required_extensions      = []
   create_extension         = true

--- a/pgvector/metadata.hcl
+++ b/pgvector/metadata.hcl
@@ -7,6 +7,7 @@ metadata = {
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = []
+  bin_path                 = []
   auto_update_os_libs      = false
   required_extensions      = []
   create_extension         = true

--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -8,6 +8,7 @@ metadata = {
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = ["system"]
+  bin_path                 = []
   auto_update_os_libs      = true
   required_extensions      = []
   create_extension         = true

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -52,10 +52,10 @@ metadata = {
   # TODO: Remove this comment block after customizing the file.
   # `bin_path`: this SHOULD be defined when your extension needs executables
   # to be present in the PATH of the PostgreSQL process to function properly.
-  # Each path is appended to the PATH environment variable for the
-  # Postgres process.
-  # If left EMPTY (`[]`) the operator will NOT alter `PATH`.
-  # Used in tests and to generate image catalogs.
+  # For most extensions, the default empty list (`[]`) is correct and the
+  # operator will NOT alter `PATH`.
+  # Each path provided is appended to the `PATH` environment variable for the
+  # Postgres process. Used in tests and to generate image catalogs.
   bin_path                 = []
 
   # TODO: Remove this comment block after customizing the file.

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -50,6 +50,15 @@ metadata = {
   ld_library_path          = []
 
   # TODO: Remove this comment block after customizing the file.
+  # `bin_path`: this SHOULD be defined when your extension needs executables
+  # to be present in the PATH of the PostgreSQL process to function properly.
+  # Each path is appended to the PATH environment variable for the
+  # Postgres process.
+  # If left EMPTY (`[]`) the operator will NOT alter `PATH`.
+  # Used in tests and to generate image catalogs.
+  bin_path                 = []
+
+  # TODO: Remove this comment block after customizing the file.
   # `auto_update_os_libs`: set to true to allow the maintenance tooling
   # to update OS libraries automatically; look at the `postgis` example.
   auto_update_os_libs      = false


### PR DESCRIPTION
Add `bin_path` to metadata structs and HCL templates to support extensions requiring custom executables in the Postgres `PATH` environment variable.
  
Relates to https://github.com/cloudnative-pg/cloudnative-pg/issues/10152