### PR TITLE
fix: Do not specify version when creating extensions

### DIFF
--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -10,7 +10,6 @@ import (
 type ExtensionSpec struct {
 	Ensure  string `yaml:"ensure"`
 	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
 }
 
 type DatabaseConfig struct {
@@ -123,7 +122,6 @@ func generateDatabaseConfig(extensionInfos []*testingExtensionInfo) *DatabaseCon
 			ExtensionSpec{
 				Ensure:  "present",
 				Name:    info.SQLName,
-				Version: info.Version,
 			},
 		)
 	}

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -11,8 +11,6 @@ spec:
         env:
           - name: EXT_SQL_NAME
             value: ($values.sql_name)
-          - name: EXT_VERSION
-            value: ($values.version)
           - name: CREATE_EXTENSION
             value: (to_string($values.create_extension))
           - name: DB_URI
@@ -30,5 +28,5 @@ spec:
              exit 0
            fi
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|")
-           test "$(psql "$DB_URI" -tAc "SELECT EXISTS (SELECT FROM pg_catalog.pg_extension WHERE extname = '${EXT_SQL_NAME}' AND extversion = '${EXT_VERSION}')" -q)" = "t"
-           echo "Extension '${EXT_SQL_NAME} v${EXT_VERSION}' is installed!"
+           test "$(psql "$DB_URI" -tAc "SELECT EXISTS (SELECT FROM pg_catalog.pg_extension WHERE extname = '${EXT_SQL_NAME}')" -q)" = "t"
+           echo "Extension '${EXT_SQL_NAME}' is installed!"


### PR DESCRIPTION
When create_extension=true, omit the version from the Database extensions spec so CNPG uses the extension's default_version from the control file. The OCI image version annotation reflects the package version, which can differ from the SQL extension version (e.g. pg_cron package 1.6.7 vs control default_version 1.6). This problem was encountered while working on #139

Also update the smoke test verification to check only that the extension exists, without requiring a specific version number.