### PR TITLE
feat: support sql version in metadata files

### DIFF
--- a/CONTRIBUTING_NEW_EXTENSION.md
+++ b/CONTRIBUTING_NEW_EXTENSION.md
@@ -76,21 +76,6 @@ remains constant, the versioning reflects the underlying Debian release:
 > upstream repositories and trigger update Pull Requests once your extension is
 > merged.
 
-#### Package Version vs. SQL Version
-
-Your `metadata.hcl` file requires two version fields:
-
-- **`package`**: The full Debian package version (e.g., `0.8.2-1.pgdg13+1`).
-  This includes packaging metadata and is used to install the correct package.
-
-- **`sql`**: The PostgreSQL extension version as it appears in the catalog
-  (e.g., `0.8.2`). This is the version of the extension that will be verified
-  as part of the automatic testing of the resulting containers. It should
-  match what is defined by the `default_version` field in the control file.
-
-The **SQL version** is optional and only needed if your extension uses
-`CREATE EXTENSION` (when `create_extension = true` in metadata).
-
 #### Inspecting the Package Content
 
 If you want to get a list of the files contained in the package, you need to
@@ -167,9 +152,26 @@ The scaffolding generates `metadata.hcl`, `Dockerfile`, and `README.md`.
 Follow the specific instructions and "TODO" comments found within each
 generated file to finalize your extension.
 
+#### Package Version vs. SQL Version
+
+Your `metadata.hcl` file requires two version fields:
+
+- **`package`**: The full Debian package version (e.g., `0.8.2-1.pgdg13+1`).
+  This includes packaging metadata and is used to install the correct package.
+
+- **`sql`**: The PostgreSQL extension version as it appears in the catalog
+  (e.g., `0.8.2`). This is the version of the extension that will be verified
+  as part of the automatic testing of the resulting containers. It should
+  match what is defined by the `default_version` field in the control file.
+
+
+> [!WARNING]
+> The `sql` version is optional and only needed if your extension uses
+> `CREATE EXTENSION` (when `create_extension = true` in metadata).
+
 > [!TIP]
-> Pay close attention to the `// renovate:` comments in the metadata; these are
-> required for automated version tracking.
+> Pay close attention to the `// renovate:` comments in the metadata and
+> `README.md` files; these are required for automated version tracking.
 
 ---
 

--- a/CONTRIBUTING_NEW_EXTENSION.md
+++ b/CONTRIBUTING_NEW_EXTENSION.md
@@ -76,6 +76,21 @@ remains constant, the versioning reflects the underlying Debian release:
 > upstream repositories and trigger update Pull Requests once your extension is
 > merged.
 
+#### Package Version vs. SQL Version
+
+Your `metadata.hcl` file requires two version fields:
+
+- **`package`**: The full Debian package version (e.g., `0.8.2-1.pgdg13+1`).
+  This includes packaging metadata and is used to install the correct package.
+
+- **`sql`**: The PostgreSQL extension version as it appears in the catalog
+  (e.g., `0.8.2`). This is the version of the extension that will be verified
+  as part of the automatic testing of the resulting containers. It should
+  match what is defined by the `default_version` field in the control file.
+
+The **SQL version** is optional and only needed if your extension uses
+`CREATE EXTENSION` (when `create_extension = true` in metadata).
+
 #### Inspecting the Package Content
 
 If you want to get a list of the files contained in the package, you need to

--- a/README.md
+++ b/README.md
@@ -138,27 +138,27 @@ other tools to identify the base PostgreSQL version and OS distribution.
 
 ### CloudNativePG-Specific Labels
 
-| Label | Description                      | Example |
-| :--- |:---------------------------------| :--- |
-| `io.cloudnativepg.image.base.name` | Base PostgreSQL container image  | `ghcr.io/cloudnative-pg/postgresql:18-minimal-bookworm` |
-| `io.cloudnativepg.image.base.pgmajor` | PostgreSQL major version         | `18` |
-| `io.cloudnativepg.image.base.os` | Operating system distribution    | `bookworm` |
-| `io.cloudnativepg.image.sql.version` | PostgreSQL extension SQL version | `0.8.2` |
+| Label                                 | Description                      | Example                                                 |
+|:--------------------------------------|:---------------------------------|:--------------------------------------------------------|
+| `io.cloudnativepg.image.base.name`    | Base PostgreSQL container image  | `ghcr.io/cloudnative-pg/postgresql:18-minimal-bookworm` |
+| `io.cloudnativepg.image.base.pgmajor` | PostgreSQL major version         | `18`                                                    |
+| `io.cloudnativepg.image.base.os`      | Operating system distribution    | `bookworm`                                              |
+| `io.cloudnativepg.image.sql.version`  | PostgreSQL extension SQL version | `0.8.2`                                                 |
 
 ### Standard OCI Labels
 
 In addition to CloudNativePG-specific labels, all images include standard OCI
 annotations as defined by the [OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md):
 
-| Label | Description |
-| :--- | :--- |
-| `org.opencontainers.image.created` | Image creation timestamp |
-| `org.opencontainers.image.version` | Extension version |
-| `org.opencontainers.image.revision` | Git commit SHA |
-| `org.opencontainers.image.title` | Human-readable image title |
-| `org.opencontainers.image.description` | Image description |
-| `org.opencontainers.image.source` | Source repository URL |
-| `org.opencontainers.image.licenses` | License identifier |
+| Label                                  | Description                 |
+|:---------------------------------------|:----------------------------|
+| `org.opencontainers.image.created`     | Image creation timestamp    |
+| `org.opencontainers.image.version`     | Extension's package version |
+| `org.opencontainers.image.revision`    | Git commit SHA              |
+| `org.opencontainers.image.title`       | Human-readable image title  |
+| `org.opencontainers.image.description` | Image description           |
+| `org.opencontainers.image.source`      | Source repository URL       |
+| `org.opencontainers.image.licenses`    | License identifier          |
 
 You can inspect these labels using container tools:
 

--- a/README.md
+++ b/README.md
@@ -138,11 +138,12 @@ other tools to identify the base PostgreSQL version and OS distribution.
 
 ### CloudNativePG-Specific Labels
 
-| Label | Description | Example |
-| :--- | :--- | :--- |
-| `io.cloudnativepg.image.base.name` | Base PostgreSQL container image | `ghcr.io/cloudnative-pg/postgresql:18-minimal-bookworm` |
-| `io.cloudnativepg.image.base.pgmajor` | PostgreSQL major version | `18` |
-| `io.cloudnativepg.image.base.os` | Operating system distribution | `bookworm` |
+| Label | Description                      | Example |
+| :--- |:---------------------------------| :--- |
+| `io.cloudnativepg.image.base.name` | Base PostgreSQL container image  | `ghcr.io/cloudnative-pg/postgresql:18-minimal-bookworm` |
+| `io.cloudnativepg.image.base.pgmajor` | PostgreSQL major version         | `18` |
+| `io.cloudnativepg.image.base.os` | Operating system distribution    | `bookworm` |
+| `io.cloudnativepg.image.sql.version` | PostgreSQL extension SQL version | `0.8.2` |
 
 ### Standard OCI Labels
 

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -147,16 +147,16 @@ func getExtensionImageWithTimestamp(metadata *extensionMetadata, distribution st
 // extractExtensionVersion returns the extension version for a given distribution and pgMajor,
 // extracted from the extension's metadata.
 func extractExtensionVersion(versions versionMap, distribution string, pgMajor int) (string, error) {
-	packageVersion := versions[distribution][strconv.Itoa(pgMajor)]
-	if packageVersion == "" {
+	extVersion, ok := versions[distribution][strconv.Itoa(pgMajor)]
+	if !ok {
 		return "", fmt.Errorf("no package version found for distribution %q and version %d",
 			distribution, pgMajor)
 	}
 
 	re := regexp.MustCompile(`^(\d+(?:\.\d+)+)`)
-	matches := re.FindStringSubmatch(packageVersion)
+	matches := re.FindStringSubmatch(extVersion.Package)
 	if len(matches) < 2 {
-		return "", fmt.Errorf("cannot extract extension version from %q", packageVersion)
+		return "", fmt.Errorf("cannot extract extension version from %q", extVersion.Package)
 	}
 
 	return matches[1], nil

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -22,6 +22,11 @@ const (
 	DefaultDistribution = "trixie"
 )
 
+const (
+	AnnotationImageSQLVersion = "io.cloudnativepg.image.sql.version"
+	AnnotationImageBaseName   = "io.cloudnativepg.image.base.name"
+)
+
 var SupportedDistributions = []string{
 	"bookworm",
 	"trixie",

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -182,7 +182,7 @@ func (m *Maintenance) GenerateTestingValues(
 	version := annotations["io.cloudnativepg.image.sql.version"]
 	if version == "" && metadata.CreateExtension {
 		return nil, fmt.Errorf(
-			"extension image %s doesn't have an 'io.cloudnativepg.image.sql.version' annotation",
+			"extension image %s doesn't have an 'io.cloudnativepg.image.sql.version' annotation or its value is empty",
 			targetExtensionImage)
 	}
 

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -172,18 +172,18 @@ func (m *Maintenance) GenerateTestingValues(
 		return nil, err
 	}
 
-	pgImage := annotations["io.cloudnativepg.image.base.name"]
+	pgImage := annotations[AnnotationImageBaseName]
 	if pgImage == "" {
 		return nil, fmt.Errorf(
-			"extension image %s doesn't have an 'io.cloudnativepg.image.base.name' annotation",
-			targetExtensionImage)
+			"extension image %s doesn't have an %q annotation or its value is empty",
+			targetExtensionImage, AnnotationImageBaseName)
 	}
 
-	version := annotations["io.cloudnativepg.image.sql.version"]
+	version := annotations[AnnotationImageSQLVersion]
 	if version == "" && metadata.CreateExtension {
 		return nil, fmt.Errorf(
-			"extension image %s doesn't have an 'io.cloudnativepg.image.sql.version' annotation or its value is empty",
-			targetExtensionImage)
+			"extension image %s doesn't have an %q annotation or its value is empty",
+			targetExtensionImage, AnnotationImageSQLVersion)
 	}
 
 	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, targetExtensionImage, version, registryUsername, registryPassword)

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -180,7 +180,7 @@ func (m *Maintenance) GenerateTestingValues(
 	}
 
 	version := annotations["io.cloudnativepg.image.sql.version"]
-	if version == "" {
+	if version == "" && metadata.CreateExtension {
 		return nil, fmt.Errorf(
 			"extension image %s doesn't have an 'io.cloudnativepg.image.sql.version' annotation",
 			targetExtensionImage)

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -179,10 +179,10 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage)
 	}
 
-	version := annotations["org.opencontainers.image.version"]
+	version := annotations["io.cloudnativepg.image.sql.version"]
 	if version == "" {
 		return nil, fmt.Errorf(
-			"extension image %s doesn't have an 'org.opencontainers.image.version' annotation",
+			"extension image %s doesn't have an 'io.cloudnativepg.image.sql.version' annotation",
 			targetExtensionImage)
 	}
 

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -20,7 +20,6 @@ type buildMatrix struct {
 
 type extensionVersion struct {
 	Package string `hcl:"package" cty:"package"`
-	Sql     string `hcl:"sql" cty:"sql"`
 }
 
 type versionMap map[string]map[string]extensionVersion

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -18,7 +18,12 @@ type buildMatrix struct {
 	MajorVersions []string
 }
 
-type versionMap map[string]map[string]string
+type extensionVersion struct {
+	Package string `hcl:"package" cty:"package"`
+	Sql     string `hcl:"sql" cty:"sql"`
+}
+
+type versionMap map[string]map[string]extensionVersion
 
 type extensionMetadata struct {
 	Name                   string     `hcl:"name" cty:"name"`

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -72,11 +72,11 @@ func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directo
 		if err != nil {
 			return nil, err
 		}
-		depVersion := depAnnotations["org.opencontainers.image.version"]
+		depVersion := depAnnotations[AnnotationImageSQLVersion]
 		if depVersion == "" {
 			return nil, fmt.Errorf(
-				"extension image %s doesn't have an 'org.opencontainers.image.version' annotation",
-				depConfiguration.ImageVolumeSource.Reference)
+				"extension image %s doesn't have an %q annotation or its value is empty",
+				depConfiguration.ImageVolumeSource.Reference, AnnotationImageSQLVersion)
 		}
 
 		out = append(out, &testingExtensionInfo{

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -79,6 +79,7 @@ target "default" {
     "index,manifest:io.cloudnativepg.image.base.name=${getBaseImage(distro, pgVersion)}",
     "index,manifest:io.cloudnativepg.image.base.pgmajor=${pgVersion}",
     "index,manifest:io.cloudnativepg.image.base.os=${distro}",
+    "index,manifest:io.cloudnativepg.image.sql.version=${getExtensionSqlVersion(distro, pgVersion)}",
   ]
   labels = {
     "org.opencontainers.image.created" = "${now}",
@@ -96,6 +97,7 @@ target "default" {
     "io.cloudnativepg.image.base.name" = "${getBaseImage(distro, pgVersion)}",
     "io.cloudnativepg.image.base.pgmajor" = "${pgVersion}",
     "io.cloudnativepg.image.base.os" = "${distro}",
+    "io.cloudnativepg.image.sql.version" = "${getExtensionSqlVersion(distro, pgVersion)}",
   }
 }
 
@@ -106,7 +108,12 @@ function getImageName {
 
 function getExtensionPackage {
   params = [ distro, pgVersion ]
-  result = metadata.versions[distro][pgVersion]
+  result = metadata.versions[distro][pgVersion]["package"]
+}
+
+function getExtensionSqlVersion {
+  params = [ distro, pgVersion ]
+  result = metadata.versions[distro][pgVersion]["sql"]
 }
 
 // Parse the packageVersion to extract the MM.mm.pp extension version.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -113,7 +113,7 @@ function getExtensionPackage {
 
 function getExtensionSqlVersion {
   params = [ distro, pgVersion ]
-  result = metadata.versions[distro][pgVersion]["sql"]
+  result = lookup(metadata.versions[distro][pgVersion], "sql", "")
 }
 
 // Parse the packageVersion to extract the MM.mm.pp extension version.

--- a/pg-crash/metadata.hcl
+++ b/pg-crash/metadata.hcl
@@ -16,12 +16,18 @@ metadata = {
 
   versions = {
     bookworm = {
-      // renovate: suite=bookworm-pgdg depName=postgresql-18-pg-crash
-      "18" = "0.3-2.pgdg12+1"
+      "18" = {
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pg-crash
+        package = "0.3-2.pgdg12+1"
+        sql     = "0.3-2"
+      }
     }
     trixie = {
-      // renovate: suite=trixie-pgdg depName=postgresql-18-pg-crash
-      "18" = "0.3-2.pgdg13+1"
+      "18" = {
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pg-crash
+        package = "0.3-2.pgdg13+1"
+        sql     = "0.3-2"
+      }
     }
   }
 }

--- a/pg-crash/metadata.hcl
+++ b/pg-crash/metadata.hcl
@@ -19,14 +19,12 @@ metadata = {
       "18" = {
         // renovate: suite=bookworm-pgdg depName=postgresql-18-pg-crash
         package = "0.3-2.pgdg12+1"
-        sql     = "0.3-2"
       }
     }
     trixie = {
       "18" = {
         // renovate: suite=trixie-pgdg depName=postgresql-18-pg-crash
         package = "0.3-2.pgdg13+1"
-        sql     = "0.3-2"
       }
     }
   }

--- a/pgaudit/README.md
+++ b/pgaudit/README.md
@@ -55,7 +55,7 @@ spec:
     name: cluster-pgaudit
   extensions:
   - name: pgaudit
-    # renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit
+    # renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit extractVersion=^(?<version>\d+\.\d+)
     version: '18.0'
 ```
 

--- a/pgaudit/metadata.hcl
+++ b/pgaudit/metadata.hcl
@@ -17,7 +17,7 @@ metadata = {
       "18" = {
         // renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
         package = "18.0-2.pgdg12+1"
-        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit extractVersion=^(?<version>\d+\.\d+).*$
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit extractVersion=^(?<version>\d+\.\d+)
         sql     = "18.0"
       }
     }
@@ -25,7 +25,7 @@ metadata = {
       "18" = {
         // renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit
         package = "18.0-2.pgdg13+1"
-        // renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit extractVersion=^(?<version>\d+\.\d+).*$
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit extractVersion=^(?<version>\d+\.\d+)
         sql     = "18.0"
       }
     }

--- a/pgaudit/metadata.hcl
+++ b/pgaudit/metadata.hcl
@@ -14,12 +14,18 @@ metadata = {
 
   versions = {
     bookworm = {
-      // renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
-      "18" = "18.0-2.pgdg12+1"
+      "18" = {
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
+        package = "18.0-2.pgdg12+1"
+        sql     = "18.0"
+      }
     }
     trixie = {
-      // renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit
-      "18" = "18.0-2.pgdg13+1"
+      "18" = {
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit
+        package = "18.0-2.pgdg13+1"
+        sql     = "18.0"
+      }
     }
   }
 }

--- a/pgaudit/metadata.hcl
+++ b/pgaudit/metadata.hcl
@@ -17,6 +17,7 @@ metadata = {
       "18" = {
         // renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit
         package = "18.0-2.pgdg12+1"
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgaudit extractVersion=^(?<version>\d+\.\d+).*$
         sql     = "18.0"
       }
     }
@@ -24,6 +25,7 @@ metadata = {
       "18" = {
         // renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit
         package = "18.0-2.pgdg13+1"
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgaudit extractVersion=^(?<version>\d+\.\d+).*$
         sql     = "18.0"
       }
     }

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -50,7 +50,7 @@ spec:
     name: cluster-pgvector
   extensions:
   - name: vector
-    # renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
+    # renovate: suite=trixie-pgdg depName=postgresql-18-pgvector extractVersion=^(?<version>\d+\.\d+\.\d+)
     version: '0.8.2'
 ```
 

--- a/pgvector/metadata.hcl
+++ b/pgvector/metadata.hcl
@@ -17,6 +17,7 @@ metadata = {
       "18" = {
         // renovate: suite=bookworm-pgdg depName=postgresql-18-pgvector
         package = "0.8.2-1.pgdg12+1"
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgvector extractVersion=^(?<version>\d+\.\d+\.\d+).*$
         sql     = "0.8.2"
       }
     }
@@ -24,6 +25,7 @@ metadata = {
       "18" = {
         // renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
         package = "0.8.2-1.pgdg13+1"
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgvector extractVersion=^(?<version>\d+\.\d+\.\d+).*$
         sql     = "0.8.2"
       }
     }

--- a/pgvector/metadata.hcl
+++ b/pgvector/metadata.hcl
@@ -14,12 +14,18 @@ metadata = {
 
   versions = {
     bookworm = {
-      // renovate: suite=bookworm-pgdg depName=postgresql-18-pgvector
-      "18" = "0.8.2-1.pgdg12+1"
+      "18" = {
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgvector
+        package = "0.8.2-1.pgdg12+1"
+        sql     = "0.8.2"
+      }
     }
     trixie = {
-      // renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
-      "18" = "0.8.2-1.pgdg13+1"
+      "18" = {
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
+        package = "0.8.2-1.pgdg13+1"
+        sql     = "0.8.2"
+      }
     }
   }
 }

--- a/pgvector/metadata.hcl
+++ b/pgvector/metadata.hcl
@@ -17,7 +17,7 @@ metadata = {
       "18" = {
         // renovate: suite=bookworm-pgdg depName=postgresql-18-pgvector
         package = "0.8.2-1.pgdg12+1"
-        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgvector extractVersion=^(?<version>\d+\.\d+\.\d+).*$
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgvector extractVersion=^(?<version>\d+\.\d+\.\d+)
         sql     = "0.8.2"
       }
     }
@@ -25,7 +25,7 @@ metadata = {
       "18" = {
         // renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
         package = "0.8.2-1.pgdg13+1"
-        // renovate: suite=trixie-pgdg depName=postgresql-18-pgvector extractVersion=^(?<version>\d+\.\d+\.\d+).*$
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgvector extractVersion=^(?<version>\d+\.\d+\.\d+)
         sql     = "0.8.2"
       }
     }

--- a/postgis/README.md
+++ b/postgis/README.md
@@ -51,7 +51,7 @@ spec:
     name: cluster-postgis
   extensions:
   - name: postgis
-    # renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
+    # renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+)
     version: '3.6.2'
   - name: postgis_raster
   - name: postgis_sfcgal

--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -18,6 +18,7 @@ metadata = {
       "18" = {
         // renovate: suite=bookworm-pgdg depName=postgresql-18-postgis-3
         package = "3.6.2+dfsg-1.pgdg12+1"
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+).*$
         sql     = "3.6.2"
       }
     }
@@ -25,6 +26,7 @@ metadata = {
       "18" = {
         // renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
         package = "3.6.2+dfsg-1.pgdg13+1"
+        // renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+).*$
         sql     = "3.6.2"
       }
     }

--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -18,7 +18,7 @@ metadata = {
       "18" = {
         // renovate: suite=bookworm-pgdg depName=postgresql-18-postgis-3
         package = "3.6.2+dfsg-1.pgdg12+1"
-        // renovate: suite=bookworm-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+).*$
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+)
         sql     = "3.6.2"
       }
     }
@@ -26,7 +26,7 @@ metadata = {
       "18" = {
         // renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
         package = "3.6.2+dfsg-1.pgdg13+1"
-        // renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+).*$
+        // renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+)
         sql     = "3.6.2"
       }
     }

--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -15,12 +15,18 @@ metadata = {
 
   versions = {
     bookworm = {
-      // renovate: suite=bookworm-pgdg depName=postgresql-18-postgis-3
-      "18" = "3.6.2+dfsg-1.pgdg12+1"
+      "18" = {
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-postgis-3
+        package = "3.6.2+dfsg-1.pgdg12+1"
+        sql     = "3.6.2"
+      }
     }
     trixie = {
-      // renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
-      "18" = "3.6.2+dfsg-1.pgdg13+1"
+      "18" = {
+        // renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
+        package = "3.6.2+dfsg-1.pgdg13+1"
+        sql     = "3.6.2"
+      }
     }
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,12 +29,23 @@
         "**/README.md"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*reference: ghcr.io\\/cloudnative-pg\\/[A-Za-z0-9_-]+:(?<currentValue>([0-9]\\.?)+)",
-        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*version: '(?<currentValue>([0-9]\\.?)+)'"
+        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*reference: ghcr.io\\/cloudnative-pg\\/[A-Za-z0-9_-]+:(?<currentValue>([0-9]\\.?)+)"
       ],
       "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",
       "datasourceTemplate": "deb",
       "extractVersionTemplate": "^(?<version>[^-+]+)"
+    },
+    {
+      "description": "updates the container image SQL version in the README.md files",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "**/README.md"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s*version: '(?<currentValue>([0-9]\\.?)+)'"
+      ],
+      "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",
+      "datasourceTemplate": "deb"
     },
     {
       "description": "updates the Taskfile dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
         "**/*.hcl"
       ],
       "matchStrings": [
-        "\\/\\/\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\s*\"[A-Za-z0-9_-]+\"\\s*=\\s*\"(?<currentValue>.*)\""
+        "\\/\\/\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s*(sql|package)\\s*=\\s*\"(?<currentValue>.*)\""
       ],
       "registryUrlTemplate": "https://download.postgresql.org/pub/repos/apt?suite={{#if suite}}{{suite}}{{else}}stable{{/if}}&components=main&binaryArch=amd64",
       "datasourceTemplate": "deb"

--- a/templates/README.md.tmpl
+++ b/templates/README.md.tmpl
@@ -62,9 +62,14 @@ spec:
     name: cluster-{{ .Name }}
   extensions:
   - name: {{ .Name }}
-    # renovate: suite={{ .DefaultDistro }}-pgdg depName={{ replaceAll .Package "%version%" (printf "%d" .DefaultVersion) }}
+    # renovate: suite={{ .DefaultDistro }}-pgdg depName={{ replaceAll .Package "%version%" (printf "%d" .DefaultVersion) }} extractVersion=^(?<version>\d+\.\d+\.\d+)
     version: '1.0'
 ```
+
+<!--
+TODO: Adjust the extractVersion regex pattern above based on your extension's versioning scheme
+Examples: \d+\.\d+ for major.minor (e.g., "18.0"), \d+\.\d+\.\d+ for major.minor.patch (e.g., "0.8.2")
+-->
 
 ### 3. Verify installation
 

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -79,8 +79,15 @@ metadata = {
     {{- range $distro := .Distros}}
     {{ $distro }} = {
         {{- range $version := $.Versions}}
-        // renovate: suite={{ $distro }}-pgdg depName={{ replaceAll $.Package "%version%" $version }}
-        "{{ $version }}" = "<package-version-here>"
+        "{{ $version }}" = {
+          // renovate: suite={{ $distro }}-pgdg depName={{ replaceAll $.Package "%version%" $version }}
+          package = "<package-version-here>"
+          // TODO: Remove this comment after adding the sql version if extension uses CREATE EXTENSION
+          // TODO: Adjust the extractVersion regex pattern based on your extension's versioning scheme
+          // Examples: \d+\.\d+ for major.minor (e.g., "18.0"), \d+\.\d+\.\d+ for major.minor.patch (e.g., "0.8.2")
+          // renovate: suite={{ $distro }}-pgdg depName={{ replaceAll $.Package "%version%" $version }} extractVersion=^(?<version>\d+\.\d+\.\d+).*$
+          sql = "<sql-version-here>"
+        }
         {{- end}}
     }
     {{- end}}

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -85,7 +85,7 @@ metadata = {
           // TODO: Remove this comment after adding the sql version if extension uses CREATE EXTENSION
           // TODO: Adjust the extractVersion regex pattern based on your extension's versioning scheme
           // Examples: \d+\.\d+ for major.minor (e.g., "18.0"), \d+\.\d+\.\d+ for major.minor.patch (e.g., "0.8.2")
-          // renovate: suite={{ $distro }}-pgdg depName={{ replaceAll $.Package "%version%" $version }} extractVersion=^(?<version>\d+\.\d+\.\d+).*$
+          // renovate: suite={{ $distro }}-pgdg depName={{ replaceAll $.Package "%version%" $version }} extractVersion=^(?<version>\d+\.\d+\.\d+)
           sql = "<sql-version-here>"
         }
         {{- end}}


### PR DESCRIPTION
## Summary

  Adds support for tracking PostgreSQL extension SQL versions separately from Debian package versions, enabling accurate version verification in E2E tests.

  ## Changes

  - **Metadata structure**: Extensions now define both `package` (Debian version) and `sql` (PostgreSQL catalog version) in `metadata.hcl`
  - **Image annotations**: New `io.cloudnativepg.image.sql.version` label added to container images
  - **E2E testing**: Chainsaw tests verify extension version against the new `sql` value
  - **Renovate support**: Updated patterns to track both package and SQL versions automatically
  - **Documentation**: Updated templates and contributing guide to explain version semantics

  ## Example

  ```hcl
  versions = {
    bookworm = {
      "18" = {
        package = "0.8.2-1.pgdg12+1"  // Full Debian package version
        sql     = "0.8.2"              // Version in PostgreSQL catalog
      }
    }
  }
```

The SQL version is optional and only required for extensions using CREATE EXTENSION (create_extension = true).

Closes #145 