### PR TITLE
feat: postgres parameters in extension metadata

### DIFF
--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -204,6 +204,7 @@ func (m *Maintenance) GenerateTestingValues(
 		Name:                   metadata.Name,
 		SQLName:                metadata.SQLName,
 		SharedPreloadLibraries: metadata.SharedPreloadLibraries,
+		PostgresqlParameters:   metadata.PostgresqlParameters,
 		PgImage:                pgImage,
 		Version:                version,
 		CreateExtension:        metadata.CreateExtension,

--- a/dagger/maintenance/parse.go
+++ b/dagger/maintenance/parse.go
@@ -25,19 +25,20 @@ type extensionVersion struct {
 type versionMap map[string]map[string]extensionVersion
 
 type extensionMetadata struct {
-	Name                   string     `hcl:"name" cty:"name"`
-	SQLName                string     `hcl:"sql_name" cty:"sql_name"`
-	ImageName              string     `hcl:"image_name" cty:"image_name"`
-	SharedPreloadLibraries []string   `hcl:"shared_preload_libraries" cty:"shared_preload_libraries"`
-	ExtensionControlPath   []string   `hcl:"extension_control_path" cty:"extension_control_path"`
-	DynamicLibraryPath     []string   `hcl:"dynamic_library_path" cty:"dynamic_library_path"`
-	LdLibraryPath          []string   `hcl:"ld_library_path" cty:"ld_library_path"`
-	BinPath                []string   `hcl:"bin_path" cty:"bin_path"`
-	AutoUpdateOsLibs       bool       `hcl:"auto_update_os_libs" cty:"auto_update_os_libs"`
-	RequiredExtensions     []string   `hcl:"required_extensions" cty:"required_extensions"`
-	CreateExtension        bool       `hcl:"create_extension" cty:"create_extension"`
-	Versions               versionMap `hcl:"versions" cty:"versions"`
-	Remain                 hcl.Body   `hcl:",remain"`
+	Name                   string            `hcl:"name" cty:"name"`
+	SQLName                string            `hcl:"sql_name" cty:"sql_name"`
+	ImageName              string            `hcl:"image_name" cty:"image_name"`
+	SharedPreloadLibraries []string          `hcl:"shared_preload_libraries" cty:"shared_preload_libraries"`
+	PostgresqlParameters   map[string]string `hcl:"postgresql_parameters" cty:"postgresql_parameters"`
+	ExtensionControlPath   []string          `hcl:"extension_control_path" cty:"extension_control_path"`
+	DynamicLibraryPath     []string          `hcl:"dynamic_library_path" cty:"dynamic_library_path"`
+	LdLibraryPath          []string          `hcl:"ld_library_path" cty:"ld_library_path"`
+	BinPath                []string          `hcl:"bin_path" cty:"bin_path"`
+	AutoUpdateOsLibs       bool              `hcl:"auto_update_os_libs" cty:"auto_update_os_libs"`
+	RequiredExtensions     []string          `hcl:"required_extensions" cty:"required_extensions"`
+	CreateExtension        bool              `hcl:"create_extension" cty:"create_extension"`
+	Versions               versionMap        `hcl:"versions" cty:"versions"`
+	Remain                 hcl.Body          `hcl:",remain"`
 }
 
 const (

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -21,6 +21,7 @@ type TestingValues struct {
 	Name                   string                    `yaml:"name"`
 	SQLName                string                    `yaml:"sql_name"`
 	SharedPreloadLibraries []string                  `yaml:"shared_preload_libraries"`
+	PostgresqlParameters   map[string]string         `yaml:"postgresql_parameters"`
 	PgImage                string                    `yaml:"pg_image"`
 	Version                string                    `yaml:"version"`
 	CreateExtension        bool                      `yaml:"create_extension"`

--- a/pg-crash/metadata.hcl
+++ b/pg-crash/metadata.hcl
@@ -6,6 +6,7 @@ metadata = {
   image_name               = "pg-crash"
   licenses                 = ["BSD-3-Clause"]
   shared_preload_libraries = ["pg_crash"]
+  postgresql_parameters    = {}
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = []

--- a/pgaudit/metadata.hcl
+++ b/pgaudit/metadata.hcl
@@ -4,6 +4,7 @@ metadata = {
   image_name               = "pgaudit"
   licenses                 = ["PostgreSQL"]
   shared_preload_libraries = ["pgaudit"]
+  postgresql_parameters    = {}
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = []

--- a/pgvector/metadata.hcl
+++ b/pgvector/metadata.hcl
@@ -4,6 +4,7 @@ metadata = {
   image_name               = "pgvector"
   licenses                 = ["PostgreSQL"]
   shared_preload_libraries = []
+  postgresql_parameters    = {}
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = []

--- a/postgis/metadata.hcl
+++ b/postgis/metadata.hcl
@@ -5,6 +5,7 @@ metadata = {
   licenses                 = [ "GPL-2.0-or-later", "MIT", "LGPL-2.1-or-later",
                                "GPL-3.0-or-later", "Apache-2.0", "PostgreSQL", "Zlib" ]
   shared_preload_libraries = []
+  postgresql_parameters    = {}
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = ["system"]

--- a/postgis/test/cluster.yaml
+++ b/postgis/test/cluster.yaml
@@ -10,5 +10,6 @@ spec:
     size: 1Gi
 
   postgresql:
+    parameters: ($values.postgresql_parameters)
     shared_preload_libraries: ($values.shared_preload_libraries)
     extensions: ($values.extensions)

--- a/templates/README.md.tmpl
+++ b/templates/README.md.tmpl
@@ -62,7 +62,7 @@ spec:
     name: cluster-{{ .Name }}
   extensions:
   - name: {{ .Name }}
-    # renovate: suite={{ .DefaultDistro }}-pgdg depName={{ replaceAll .Package "%version%" (printf "%d" .DefaultVersion) }} extractVersion=^(?<version>\d+\.\d+\.\d+)
+    # renovate: suite={{ .DefaultDistro }}-pgdg depName={{ replaceAll .Package "%version%" (printf "%d" .DefaultVersion) }} extractVersion=^(?<version>\d+\.\d+)
     version: '1.0'
 ```
 

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -29,7 +29,11 @@ metadata = {
 
   # TODO: Remove this comment block after customizing the file.
   # `postgresql_parameters`: custom PostgreSQL configuration parameters to be set
-  # for this extension. Usually empty.
+  # for this extension. This is a map of key-value pairs.
+  # This option should be reserved for parameters that are strictly necessary
+  # for the extension to function properly. Avoid setting parameters that just
+  # customize the behavior of the extension.
+  # Usually empty.
   # Used in tests.
   # Example: { "pgaudit.log_client" = "on" }.
   postgresql_parameters    = {}

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -28,6 +28,13 @@ metadata = {
   shared_preload_libraries = []
 
   # TODO: Remove this comment block after customizing the file.
+  # `postgresql_parameters`: custom PostgreSQL configuration parameters to be set
+  # for this extension. Usually empty.
+  # Used in tests.
+  # Example: { "pgaudit.log_client" = "on" }.
+  postgresql_parameters    = {}
+
+  # TODO: Remove this comment block after customizing the file.
   # `extension_control_path`: if EMPTY (`[]`), the operator follows the CNPG
   # convention and will add the image's `share` directory to
   # `extension_control_path`. Usually empty.

--- a/test/cluster.yaml
+++ b/test/cluster.yaml
@@ -10,5 +10,6 @@ spec:
     size: 1Gi
 
   postgresql:
+    parameters: ($values.postgresql_parameters)
     shared_preload_libraries: ($values.shared_preload_libraries)
     extensions: ($values.extensions)


### PR DESCRIPTION
Adds support for defining PostgreSQL configuration parameters in extension metadata for use in Chainsaw e2e tests. Extensions can now specify `postgresql_parameters` in `metadata.hcl` (e.g., `{"pgaudit.log_client" = "on"}`)

Closes #153 