### PR TITLE
Add pg_oidc_validator extension

### DIFF
--- a/pg-oidc-validator/Dockerfile
+++ b/pg-oidc-validator/Dockerfile
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+FROM $BASE AS builder
+
+ARG PG_MAJOR
+ARG EXT_VERSION
+
+USER 0
+
+RUN set -eux && \
+	# Initial system libraries
+	ldconfig -p | awk '{print $NF}' | grep '^/' | sort | uniq > /tmp/base-image-libs.out && \
+	# Install runtime dependency (libcurl) and download tool
+	apt-get update && \
+	apt-get install -y --no-install-recommends wget libcurl4 && \
+	# Download and install extension from GitHub releases ("latest" tag)
+	wget -q -O /tmp/pg-oidc-validator.deb \
+		"https://github.com/Percona-Lab/pg_oidc_validator/releases/download/latest/pg-oidc-validator-pgdg${PG_MAJOR}.deb" && \
+	dpkg -i /tmp/pg-oidc-validator.deb && \
+	rm /tmp/pg-oidc-validator.deb
+
+# Gather system libraries not already in the base image
+RUN mkdir -p /system /licenses && \
+	ldd /usr/lib/postgresql/${PG_MAJOR}/lib/pg_oidc_validator.so \
+		| awk '{print $3}' | grep '^/' | sort | uniq > /tmp/all-deps.out && \
+	comm -13 /tmp/base-image-libs.out /tmp/all-deps.out > /tmp/libraries.out && \
+	while read -r lib; do \
+		resolved=$(readlink -f "$lib"); \
+		dir=$(dirname "$lib"); \
+		base=$(basename "$lib"); \
+		cp -a "$resolved" /system/; \
+		for file in "$dir"/"${base%.so*}.so"*; do \
+			[ -e "$file" ] || continue; \
+			if [ -L "$file" ] && [ "$(readlink -f "$file")" = "$resolved" ]; then \
+				ln -sf "$(basename "$resolved")" "/system/$(basename "$file")"; \
+			fi; \
+		done; \
+	done < /tmp/libraries.out && \
+	# Get licenses for each system library
+	for lib in $(find /system -maxdepth 1 -type f -name '*.so*'); do \
+		pkg=$(dpkg -S "$(basename "$lib")" | grep -v "diversion by" | awk -F: '/:/{print $1; exit}'); \
+		[ -z "$pkg" ] && continue; \
+		mkdir -p "/licenses/$pkg" && cp -a "/usr/share/doc/$pkg/copyright" "/licenses/$pkg/copyright"; \
+	done
+
+FROM scratch
+ARG PG_MAJOR
+
+# Licenses
+COPY --from=builder /licenses /licenses/
+
+# Libraries
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/pg_oidc_validator.so /lib/
+
+# System libs (libcurl and transitive dependencies)
+COPY --from=builder /system /system/
+
+USER 65532:65532

--- a/pg-oidc-validator/README.md
+++ b/pg-oidc-validator/README.md
@@ -1,0 +1,102 @@
+# pg_oidc_validator
+<!--
+SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+[pg_oidc_validator](https://github.com/percona/pg_oidc_validator) is an
+experimental OAuth validator library for PostgreSQL 18, developed by Percona.
+It validates JWT access tokens issued by OIDC providers, enabling native OAuth
+authentication via `pg_hba.conf`. It supports most providers that implement
+OIDC and return a valid JWT as an access token, including Keycloak and
+Microsoft Entra ID. For more information, see the
+[official documentation](https://github.com/percona/pg_oidc_validator#readme).
+
+> [!WARNING]
+> **This library is still experimental and not intended for production use.**
+> It is built from pre-compiled `.deb` packages published on GitHub (not from
+> PGDG) and is only available for the `linux/amd64` platform. There is no
+> `arm64` build available at this time.
+
+## Usage
+
+The `pg_oidc_validator` extension is **not** a `CREATE EXTENSION` module.
+It is an OAuth validator library loaded via the `oauth_validator_libraries`
+PostgreSQL configuration parameter.
+
+### 1. Add the pg-oidc-validator extension image to your Cluster
+
+Define the `pg-oidc-validator` extension under the `postgresql.extensions`
+section of your `Cluster` resource. For example:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pg-oidc-validator
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    parameters:
+      oauth_validator_libraries: pg_oidc_validator
+    extensions:
+    - name: pg-oidc-validator
+      image:
+        reference: ghcr.io/cloudnative-pg/pg-oidc-validator:0.2-18-trixie
+    pg_hba:
+    - host all all 0.0.0.0/0 oauth scope="openid",issuer=https://your-oidc-issuer
+```
+
+### 2. Verify installation
+
+Once the cluster is ready, connect to it and check the library is loaded:
+
+```sql
+SHOW oauth_validator_libraries;
+```
+
+You should see `pg_oidc_validator` in the output.
+
+## System library dependencies
+
+This extension depends on `libcurl` and its transitive dependencies for
+making HTTPS calls to OIDC providers. These system libraries are bundled
+automatically during the image build and placed under `/system/`.
+
+## Contributors
+
+This extension is maintained by:
+
+- Erling Kristiansen (@egkristi)
+
+The maintainers are responsible for:
+
+- Monitoring upstream releases and security vulnerabilities.
+- Ensuring compatibility with supported PostgreSQL versions.
+- Reviewing and merging contributions specific to this extension's container
+  image and lifecycle.
+
+---
+
+## Licenses and Copyright
+
+This container image contains software that may be licensed under various
+open-source licenses.
+
+The `pg_oidc_validator` library is licensed under the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+All relevant license and copyright information for bundled system library
+dependencies are included within the image at:
+
+```text
+/licenses/
+```
+
+By using this image, you agree to comply with the terms of the licenses
+contained therein.

--- a/pg-oidc-validator/metadata.hcl
+++ b/pg-oidc-validator/metadata.hcl
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
+metadata = {
+  name                     = "pg-oidc-validator"
+  sql_name                 = "pg_oidc_validator"
+  image_name               = "pg-oidc-validator"
+  licenses                 = ["Apache-2.0"]
+  shared_preload_libraries = []
+  extension_control_path   = []
+  dynamic_library_path     = []
+  ld_library_path          = ["system"]
+  bin_path                 = []
+  auto_update_os_libs      = false
+  required_extensions      = []
+  create_extension         = false
+
+  versions = {
+    bookworm = {
+      "18" = "0.2"
+    }
+    trixie = {
+      "18" = "0.2"
+    }
+  }
+}
+
+target "default" {
+  name = "${metadata.name}-${sanitize(getExtensionVersion(distro, pgVersion))}-${pgVersion}-${distro}"
+  matrix = {
+    pgVersion = pgVersions
+    distro    = distributions
+  }
+
+  platforms = [
+    "linux/amd64"
+  ]
+}


### PR DESCRIPTION
An experimental OAuth validator library for PostgreSQL 18, developed by Percona.
This library is still experimental and not intended for production use.
