### PR TITLE
ci: use hosted runners when running from the cloudnative-pg org

### DIFF
--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   testbuild:
     name: Build ${{ inputs.extension_name }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Relates to cloudnative-pg/cloudnative-pg#10226