### PR TITLE
test: update default CNPG release to v1.29

### DIFF
--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{fromJson(needs.testbuild.outputs.images)}}
-        cnpg: ["main", "1.27", "1.28"]
+        cnpg: ["main", "1.28", "1.29"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -137,8 +137,10 @@ jobs:
           curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
 
       - name: Set up environment
+        env:
+          CNPG_RELEASE: ${{ matrix.cnpg }}
         run: |
-          task e2e:setup-env
+          task e2e:setup-env CNPG_RELEASE=$CNPG_RELEASE
 
       - name: Generate Chainsaw testing values
         env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,8 @@ vars:
   KIND_NODE_VERSION: v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab
   K8S_VERSION: '{{ regexReplaceAll "^v([0-9.]+).*" .KIND_NODE_VERSION "$1" }}'
   KIND_CLUSTER_NAME: pg-extensions-{{ .K8S_VERSION }}
+  # renovate: datasource=github-tags depName=cloudnative-pg/cloudnative-pg versioning=semver extractVersion=^v(?<version>\d+\.\d+)\.\d+$
+  CNPG_RELEASE_DEFAULT: 1.29
 
 tasks:
   default:
@@ -278,8 +280,7 @@ tasks:
           REGISTRY_USERNAME: '{{ .REGISTRY_USERNAME }}'
     internal: true
     vars:
-      # renovate: datasource=github-tags depName=cloudnative-pg/cloudnative-pg versioning=semver extractVersion=^v(?<version>\d+\.\d+)\.\d+$
-      CNPG_RELEASE: 1.28
+      CNPG_RELEASE: '{{ .CNPG_RELEASE | default .CNPG_RELEASE_DEFAULT }}'
       # renovate: datasource=docker depName=alpine/kubectl versioning=docker
       KUBECTL_VERSION: 1.35.3@sha256:ebf9d81d06441b3183fdc6e2dbc9f5d0db4d0464808b5bcd3c9021f54f6e65db
       DOCKER_SOCKET:
@@ -347,6 +348,7 @@ tasks:
     vars:
       REGISTRY_HOST: '{{ .REGISTRY_HOST | default "" }}'
       REGISTRY_USERNAME: '{{ .REGISTRY_USERNAME | default "" }}'
+      CNPG_RELEASE: '{{ .CNPG_RELEASE | default .CNPG_RELEASE_DEFAULT }}'
     deps:
       - e2e:start-container-registry
       - e2e:start-dagger-engine
@@ -354,6 +356,7 @@ tasks:
         vars:
           REGISTRY_HOST: '{{ .REGISTRY_HOST }}'
           REGISTRY_USERNAME: '{{ .REGISTRY_USERNAME }}'
+          CNPG_RELEASE: '{{ .CNPG_RELEASE }}'
     cmds:
       - echo -e "{{.GREEN}}--- E2E environment setup complete ---{{.NC}}"
 
@@ -421,11 +424,13 @@ tasks:
       DISTRO: '{{ .DISTRO | default "trixie" }}'
       REGISTRY_HOST: '{{ .REGISTRY_HOST | default "" }}'
       REGISTRY_USERNAME: '{{ .REGISTRY_USERNAME | default "" }}'
+      CNPG_RELEASE: '{{ .CNPG_RELEASE | default .CNPG_RELEASE_DEFAULT }}'
     cmds:
       - task: e2e:setup-env
         vars:
           REGISTRY_HOST: '{{ .REGISTRY_HOST }}'
           REGISTRY_USERNAME: '{{ .REGISTRY_USERNAME }}'
+          CNPG_RELEASE: '{{ .CNPG_RELEASE }}'
       - task: bake
         vars:
           PUSH: "true"


### PR DESCRIPTION
Update the default CNPG release to v1.29.

Allow overriding the deafult CNPG release when running `task e2e:setup-env` and `task e2e:test:full`.
Properly propagate the `CNPG_RELEASE` variable in the `smoke-test` job.

Closes #173 