### PR TITLE
feat(extension): add pglinter

### DIFF
--- a/pglinter/Dockerfile
+++ b/pglinter/Dockerfile
@@ -1,0 +1,49 @@
+# Build stage - extract extension files from .deb package
+FROM ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie AS builder
+
+ARG PG_MAJOR=18
+ARG EXT_VERSION=2.0.0
+
+USER 0
+
+RUN set -eux; \
+	ARCH=$(dpkg --print-architecture); \
+	mkdir -p /extension-build && \
+	apt-get update && \
+	apt-get install -y --no-install-recommends wget ca-certificates && \
+	cd /tmp && \
+	DOWNLOAD_URL="https://github.com/pmpetit/pglinter/releases/download/${EXT_VERSION}/postgresql_pglinter_${PG_MAJOR}_${EXT_VERSION}_${ARCH}.deb" && \
+	echo "Downloading pglinter from: $DOWNLOAD_URL" && \
+	wget -O pglinter.deb "$DOWNLOAD_URL" && \
+	dpkg-deb -x pglinter.deb /tmp/extracted && \
+	echo "Contents of extracted package:" && \
+	find /tmp/extracted -type f && \
+	# Create CloudNative-PG compliant directory structure
+	mkdir -p /extension-build/lib /extension-build/share/extension && \
+	# Copy shared libraries (.so files)
+	if [ -d /tmp/extracted/usr/lib/postgresql/${PG_MAJOR}/lib ]; then \
+		echo "Copying libraries from /usr/lib/postgresql/${PG_MAJOR}/lib/"; \
+		find /tmp/extracted/usr/lib/postgresql/${PG_MAJOR}/lib/ -name "*.so" -exec cp {} /extension-build/lib/ \; ; \
+	fi && \
+	# Copy extension control and SQL files
+	if [ -d /tmp/extracted/usr/share/postgresql/${PG_MAJOR}/extension ]; then \
+		echo "Copying extension files from /usr/share/postgresql/${PG_MAJOR}/extension/"; \
+		cp /tmp/extracted/usr/share/postgresql/${PG_MAJOR}/extension/* /extension-build/share/extension/ ; \
+	fi && \
+	echo "Final extension structure:" && \
+	find /extension-build -type f
+
+FROM scratch
+ARG PG_MAJOR=18
+
+# Final image - scratch base following CloudNative-PG specifications
+# Licenses
+COPY copyright /licenses/postgresql-${PG_MAJOR}-pglinter/
+
+COPY --from=builder /extension-build/lib/ /lib/
+COPY --from=builder /extension-build/share/ /share/
+
+# Share
+COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/pglinter* /share/extension/
+
+USER 65532:65532

--- a/pglinter/README.md
+++ b/pglinter/README.md
@@ -1,0 +1,63 @@
+# pglinter
+
+[pglinter](https://github.com/pmpetit/pglinter) is an open-source extension
+that checks **database design** in PostgreSQL.
+
+This image provides a convenient way to deploy and manage `pglinter` with
+[CloudNativePG](https://cloudnative-pg.io/).
+
+## Usage
+
+### 1. Add the pglinter extension image to your Cluster
+
+Define the `pglinter` extension under the `postgresql.extensions` section of
+your `Cluster` resource. For example:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pglinter
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    extensions:
+    - name: pglinter
+      image:
+        reference: ghcr.io/cloudnative-pg/pglinter:2.0.0-18-trixie
+```
+
+### 2. Enable the extension in a database
+
+You can install `pglinter` in a specific database by creating or updating a
+`Database` resource. For example, to enable it in the `app` database:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: cluster-pglinter-app
+spec:
+  name: app
+  owner: app
+  cluster:
+    name: cluster-pglinter
+  extensions:
+  - name: pglinter
+    version: '2.0.0'
+```
+
+### 3. Verify installation
+
+Once the database is ready, connect to it with `psql` and run:
+
+```sql
+\dx
+```
+
+You should see `pglinter` listed among the installed extensions.

--- a/pglinter/copyright
+++ b/pglinter/copyright
@@ -1,0 +1,24 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: pglinter
+Source: https://github.com/pmpetit/pglinter
+
+Files: *
+Copyright: Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+           Portions Copyright (c) 1994, The Regents of the University of California
+License: PostgreSQL
+ Permission to use, copy, modify, and distribute this software and its
+ documentation for any purpose, without fee, and without a written agreement
+ is hereby granted, provided that the above copyright notice and this
+ paragraph and the following two paragraphs appear in all copies.
+ .
+ IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+ DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+ DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ .
+ THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/pglinter/metadata.hcl
+++ b/pglinter/metadata.hcl
@@ -1,0 +1,21 @@
+metadata = {
+  name                     = "pglinter"
+  sql_name                 = "pglinter"
+  image_name               = "pglinter"
+  shared_preload_libraries = []
+  extension_control_path   = []
+  dynamic_library_path     = []
+  ld_library_path          = []
+  auto_update_os_libs      = false
+
+  versions = {
+    bookworm = {
+      // renovate: suite=bookworm-pgdg depName=postgresql-18-pglinter
+      "18" = "2.0.0"
+    }
+    trixie = {
+      // renovate: suite=trixie-pgdg depName=postgresql-18-pglinter
+      "18" = "2.0.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces the `pglinter` PostgreSQL extension for CloudNativePG, providing all necessary packaging, documentation, and metadata to support its deployment and management. The main changes include adding a multi-stage `Dockerfile` for building a CloudNativePG-compliant extension image, usage documentation, license information, and integration metadata.

Fixes : [#69](https://github.com/cloudnative-pg/postgres-extensions-containers/issues/69)

**CloudNativePG extension packaging:**
* Added a multi-stage `Dockerfile` (`pglinter/Dockerfile`) that extracts the `pglinter` extension from its `.deb` package and builds a minimal, CloudNativePG-compatible container image. This ensures the extension can be deployed as a sidecar image according to CloudNativePG standards.

**Documentation and metadata:**
* Added a `README.md` (`pglinter/README.md`) with instructions for deploying and enabling the `pglinter` extension in a CloudNativePG cluster, including example manifests and verification steps.
* Added a `metadata.hcl` (`pglinter/metadata.hcl`) file describing the extension’s metadata, supported versions, and integration points for the CloudNativePG ecosystem.

**Licensing:**
* Added a `copyright` file (`pglinter/copyright`) with licensing information for the extension.