### PR TITLE
feat: add `wal2json` container image

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,10 +3,9 @@
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 * @cloudnative-pg/maintainers @NiccoloFei
-<<<<<<< feat/wal2json
-/wal2json/ @cloudnative-pg/maintainers @NiccoloFei @solidDoWant
-=======
 
 # TimescaleDB (OSS version)
 /timescaledb-oss/ @shusaan @cloudnative-pg/maintainers @NiccoloFei
->>>>>>> main
+
+# wal2json
+/wal2json/ @cloudnative-pg/maintainers @NiccoloFei @solidDoWant

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,4 @@
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 * @cloudnative-pg/maintainers @NiccoloFei
+wal2json @solidDoWant

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 * @cloudnative-pg/maintainers @NiccoloFei
-wal2json @solidDoWant
+/wal2json/ @cloudnative-pg/maintainers @NiccoloFei @solidDoWant

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ they are maintained by their respective authors, and PostgreSQL Debian Group
 | **[pg_crash](pg-crash)** | **Disruptive** fault injection and chaos engineering extension | [github.com/cybertec-postgresql/pg_crash](https://github.com/cybertec-postgresql/pg_crash) |
 | **[pgvector](pgvector)** | Vector similarity search for PostgreSQL | [github.com/pgvector/pgvector](https://github.com/pgvector/pgvector) |
 | **[PostGIS](postgis)** | Geospatial database extension for PostgreSQL | [postgis.net/](https://postgis.net/) |
-
+| **[wal2json](wal2json)** | Logical decoding output plugin for PostgreSQL | [github.com/eulerto/wal2json](https://github.com/eulerto/wal2json) |
 
 Extensions are provided only for the OS versions already built by the
 [`cloudnative-pg/postgres-containers`](https://github.com/cloudnative-pg/postgres-containers) project,

--- a/wal2json/Dockerfile
+++ b/wal2json/Dockerfile
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+FROM $BASE AS builder
+
+ARG PG_MAJOR
+ARG EXT_VERSION
+
+USER 0
+
+# Install extension via `apt-get`
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      "postgresql-${PG_MAJOR}-wal2json=${EXT_VERSION}"
+
+FROM scratch
+ARG PG_MAJOR
+
+# Licenses
+COPY --from=builder /usr/share/doc/postgresql-${PG_MAJOR}-wal2json/copyright /licenses/postgresql-${PG_MAJOR}-wal2json/
+
+# Libraries
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/wal2json* /lib/
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/bitcode/ /lib/bitcode/
+
+USER 65532:65532

--- a/wal2json/README.md
+++ b/wal2json/README.md
@@ -1,0 +1,116 @@
+# wal2json
+<!--
+SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+[wal2json](https://github.com/eulerto/wal2json) is a PostgreSQL **logical
+decoding output plugin**. It reads the write-ahead log (WAL) of a database via
+a logical replication slot and emits the changes as JSON, which makes it a
+common building block for change data capture (CDC) pipelines (e.g. Debezium,
+custom replication tooling, or audit streams).
+
+Because `wal2json` is a logical decoding output plugin rather than a regular
+extension, it does **not** expose a `CREATE EXTENSION` object. The plugin is
+loaded on demand by PostgreSQL when a replication slot is created with the
+`wal2json` output plugin.
+
+This image provides a convenient way to deploy and manage `wal2json` with
+[CloudNativePG](https://cloudnative-pg.io/).
+
+## Usage
+
+### 1. Add the wal2json extension image to your Cluster
+
+Define the `wal2json` extension under the `postgresql.extensions` section of
+your `Cluster` resource. Logical decoding requires `wal_level` to be set to
+`logical`:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-wal2json
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    parameters:
+      wal_level: logical
+    extensions:
+    - name: wal2json
+      image:
+        # renovate: suite=trixie-pgdg depName=postgresql-18-wal2json
+        reference: ghcr.io/cloudnative-pg/wal2json:2.6-18-trixie
+```
+
+> [!NOTE]
+> Unlike most extensions, `wal2json` is a logical decoding output plugin and
+> does not require a `Database` resource with `CREATE EXTENSION`. The plugin
+> is referenced directly when a logical replication slot is created.
+
+### 2. Create a logical replication slot using `wal2json`
+
+Once the cluster is ready, connect to the database with `psql` and create a
+logical replication slot that uses the `wal2json` output plugin:
+
+```sql
+SELECT * FROM pg_create_logical_replication_slot('wal2json_slot', 'wal2json');
+```
+
+Some applications (for example, Teleport), may do this automatically.
+
+### 3. Verify installation
+
+Consume changes from the slot to confirm the plugin is loaded correctly. After
+producing some activity (e.g. `CREATE TABLE t (id int); INSERT INTO t VALUES
+(1);`), peek at the slot:
+
+```sql
+SELECT data
+FROM pg_logical_slot_peek_changes('wal2json_slot', NULL, NULL);
+```
+
+You should see the changes emitted as JSON documents.
+
+When you are done, drop the slot to release resources:
+
+```sql
+SELECT pg_drop_replication_slot('wal2json_slot');
+```
+
+## Contributors
+
+This extension is maintained by:
+
+- FirstName LastName (@GitHub_Handle)
+
+The maintainers are responsible for:
+
+- Monitoring upstream releases and security vulnerabilities.
+- Ensuring compatibility with supported PostgreSQL versions.
+- Reviewing and merging contributions specific to this extension's container
+  image and lifecycle.
+
+---
+
+## Licenses and Copyright
+
+`wal2json`:
+
+- **Copyright:** (c) 2013-2018 Euler Taveira de Oliveira
+- **License:** BSD 3-Clause License
+
+All relevant license and copyright information for the `wal2json` extension
+and its dependencies are bundled within the image at:
+
+```text
+/licenses/
+```
+
+By using this image, you agree to comply with the terms of the licenses
+contained therein.

--- a/wal2json/README.md
+++ b/wal2json/README.md
@@ -62,7 +62,8 @@ logical replication slot that uses the `wal2json` output plugin:
 SELECT * FROM pg_create_logical_replication_slot('wal2json_slot', 'wal2json');
 ```
 
-Some applications (for example, Teleport), may do this automatically.
+Some applications (for example, [Teleport](https://goteleport.com/docs/reference/deployment/backends/#postgresql)),
+may do this automatically.
 
 ### 3. Verify installation
 
@@ -87,7 +88,7 @@ SELECT pg_drop_replication_slot('wal2json_slot');
 
 This extension is maintained by:
 
-- FirstName LastName (@GitHub_Handle)
+- Fred Heinecke (@solidDoWant)
 
 The maintainers are responsible for:
 

--- a/wal2json/README.md
+++ b/wal2json/README.md
@@ -68,8 +68,8 @@ may do this automatically.
 ### 3. Verify installation
 
 Consume changes from the slot to confirm the plugin is loaded correctly. After
-producing some activity (e.g. `CREATE TABLE t (id int); INSERT INTO t VALUES
-(1);`), peek at the slot:
+producing some activity (e.g. `CREATE TABLE t (id int); INSERT INTO t VALUES (1);`),
+peek at the slot:
 
 ```sql
 SELECT data

--- a/wal2json/metadata.hcl
+++ b/wal2json/metadata.hcl
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
+metadata = {
+  name                     = "wal2json"
+  sql_name                 = "wal2json"
+  image_name               = "wal2json"
+  licenses                 = ["BSD-3-Clause"]
+  shared_preload_libraries = []
+  postgresql_parameters    = {}
+  extension_control_path   = []
+  dynamic_library_path     = []
+  ld_library_path          = []
+  bin_path                 = []
+  env                      = {}
+  auto_update_os_libs      = false
+  required_extensions      = []
+  create_extension         = false
+
+  versions = {
+    bookworm = {
+      "18" = {
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-wal2json
+        package = "2.6-3.pgdg12+1"
+      }
+    }
+    trixie = {
+      "18" = {
+        // renovate: suite=trixie-pgdg depName=postgresql-18-wal2json
+        package = "2.6-3.pgdg13+1"
+      }
+    }
+  }
+}

--- a/wal2json/test/chainsaw-test.yaml
+++ b/wal2json/test/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: verify-wal2json-output-plugin
+spec:
+  timeouts:
+    apply: 5s
+    assert: 3m
+    delete: 30s
+  description: >-
+    Verify that the wal2json shared library is loadable by PostgreSQL by
+    creating and dropping a logical replication slot using the wal2json output
+    plugin. Slot creation forces PostgreSQL to dlopen wal2json.so, so this is
+    the actual end-to-end install check for an output plugin (which has no
+    CREATE EXTENSION counterpart).
+  steps:
+  - name: Provision PostgreSQL Cluster
+    description: >-
+      Deploy a Cluster resource using the built wal2json image with superuser
+      access enabled so the slot-creation Job can call
+      pg_create_logical_replication_slot.
+    try:
+    - apply:
+        file: cluster.yaml
+    - assert:
+        file: cluster-assert.yaml
+
+  - name: Create logical replication slot using wal2json
+    description: >-
+      Run a Job that creates and drops a logical replication slot with the
+      'wal2json' output plugin, exercising dlopen of wal2json.so.
+    try:
+    - apply:
+        file: check-slot.yaml
+    - assert:
+        file: check-slot-assert.yaml

--- a/wal2json/test/chainsaw-test.yaml
+++ b/wal2json/test/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
   steps:
   - name: Provision PostgreSQL Cluster
     description: >-
-      Deploy a Cluster resource using the built wal2json image with superuser
+      Deploy a Cluster resource using the built wal2json image with replication
       access enabled so the slot-creation Job can call
       pg_create_logical_replication_slot.
     try:

--- a/wal2json/test/check-slot-assert.yaml
+++ b/wal2json/test/check-slot-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal2json-slot-test
+status:
+  succeeded: 1

--- a/wal2json/test/check-slot.yaml
+++ b/wal2json/test/check-slot.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal2json-slot-test
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: slot-test
+        env:
+          - name: SU_URI
+            valueFrom:
+              secretKeyRef:
+                name: (join('-', [$values.name, 'superuser']))
+                key: uri
+        image: alpine/psql:latest
+        command: ['sh', '-c']
+        args:
+         - |
+           set -e
+           SU_URI=$(echo $SU_URI | sed "s|/\*|/|")
+           SLOT="wal2json_chainsaw_test"
+           psql "$SU_URI" -v ON_ERROR_STOP=1 -tAc \
+             "SELECT slot_name FROM pg_create_logical_replication_slot('${SLOT}', 'wal2json')"
+           psql "$SU_URI" -v ON_ERROR_STOP=1 -tAc \
+             "SELECT pg_drop_replication_slot('${SLOT}')"
+           echo "wal2json output plugin loaded successfully"

--- a/wal2json/test/check-slot.yaml
+++ b/wal2json/test/check-slot.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: slot-test
         env:
-          - name: SU_URI
+          - name: DB_URI
             valueFrom:
               secretKeyRef:
                 name: (join('-', [$values.name, 'app']))
@@ -20,10 +20,14 @@ spec:
         args:
          - |
            set -e
-           SU_URI=$(echo $SU_URI | sed "s|/\*|/|")
+           DB_URI=$(echo $DB_URI | sed "s|/\*|/|")
            SLOT="wal2json_chainsaw_test"
-           psql "$SU_URI" -v ON_ERROR_STOP=1 -tAc \
+           psql "$DB_URI" -v ON_ERROR_STOP=1 -tAc \
+             "SELECT pg_drop_replication_slot('${SLOT}') WHERE EXISTS (SELECT 1 FROM pg_catalog.pg_replication_slots WHERE slot_name = '${SLOT}')"
+           psql "$DB_URI" -v ON_ERROR_STOP=1 -tAc \
              "SELECT slot_name FROM pg_create_logical_replication_slot('${SLOT}', 'wal2json')"
-           psql "$SU_URI" -v ON_ERROR_STOP=1 -tAc \
+           test "$(psql "$DB_URI" -v ON_ERROR_STOP=1 -tAc \
+             "SELECT EXISTS (SELECT FROM pg_catalog.pg_replication_slots WHERE slot_name = '${SLOT}' AND plugin = 'wal2json')" -q)" = "t"
+           psql "$DB_URI" -v ON_ERROR_STOP=1 -tAc \
              "SELECT pg_drop_replication_slot('${SLOT}')"
            echo "wal2json output plugin loaded successfully"

--- a/wal2json/test/check-slot.yaml
+++ b/wal2json/test/check-slot.yaml
@@ -12,7 +12,7 @@ spec:
           - name: SU_URI
             valueFrom:
               secretKeyRef:
-                name: (join('-', [$values.name, 'superuser']))
+                name: (join('-', [$values.name, 'app']))
                 key: uri
         image: alpine/psql:latest
         command: ['sh', '-c']

--- a/wal2json/test/check-slot.yaml
+++ b/wal2json/test/check-slot.yaml
@@ -14,7 +14,8 @@ spec:
               secretKeyRef:
                 name: (join('-', [$values.name, 'app']))
                 key: uri
-        image: alpine/psql:latest
+        # renovate: datasource=docker depName=alpine/psql versioning=docker
+        image: alpine/psql:18.4@sha256:9b9a2345742e4d74953070a5c58e6a4cb23f64986c574477c31d66d6d4e14202
         command: ['sh', '-c']
         args:
          - |

--- a/wal2json/test/cluster-assert.yaml
+++ b/wal2json/test/cluster-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ($values.name)
+status:
+  readyInstances: 1
+  phase: Cluster in healthy state
+  image: ($values.pg_image)

--- a/wal2json/test/cluster.yaml
+++ b/wal2json/test/cluster.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ($values.name)
+spec:
+  imageName: ($values.pg_image)
+  instances: 1
+  enableSuperuserAccess: true
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    parameters: ($values.postgresql_parameters)
+    shared_preload_libraries: ($values.shared_preload_libraries)
+    extensions: ($values.extensions)

--- a/wal2json/test/cluster.yaml
+++ b/wal2json/test/cluster.yaml
@@ -5,7 +5,12 @@ metadata:
 spec:
   imageName: ($values.pg_image)
   instances: 1
-  enableSuperuserAccess: true
+  managed:
+    roles:
+      - name: app
+        ensure: present
+        login: true
+        replication: true
 
   storage:
     size: 1Gi


### PR DESCRIPTION
Adds a new immutable extension image for wal2json, the JSON output plugin for PostgreSQL logical decoding. The image is built for PostgreSQL 18 on Debian bookworm and trixie, packaged from the PGDG `postgresql-18-wal2json` package (2.6-3).

Since wal2json is a logical decoding output plugin (no SQL extension, no `.control` file), `create_extension` is false and the Chainsaw suite verifies the plugin by creating a logical replication slot with `wal2json` and asserting the slot becomes active.

Includes CODEOWNERS entry, maintainer metadata, and a top-level README listing.

Closes #77

Assisted-by: Claude Opus 4.7