### PR TITLE
feat: add `pg_cron` container image

### DIFF
--- a/pg-cron/Dockerfile
+++ b/pg-cron/Dockerfile
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+FROM $BASE AS builder
+
+ARG PG_MAJOR
+ARG EXT_VERSION
+
+USER 0
+
+# Install extension via `apt-get`
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      "postgresql-${PG_MAJOR}-cron=${EXT_VERSION}"
+
+FROM scratch
+ARG PG_MAJOR
+
+# Licenses
+COPY --from=builder /usr/share/doc/postgresql-${PG_MAJOR}-cron/copyright /licenses/postgresql-${PG_MAJOR}-cron/
+
+# Libraries
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/pg_cron* /lib/
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/bitcode/ /lib/bitcode/
+
+# Share
+COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/pg_cron* /share/extension/
+
+USER 65532:65532

--- a/pg-cron/README.md
+++ b/pg-cron/README.md
@@ -1,0 +1,102 @@
+# pg_cron
+<!--
+SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+The [pg_cron](https://github.com/citusdata/pg_cron) PostgreSQL extension
+provides a simple cron-based job scheduler that runs inside the database as an
+extension. It uses the same syntax as regular cron, while allowing you to
+schedule PostgreSQL commands directly from the database. For more information,
+see the [official documentation](https://github.com/citusdata/pg_cron).
+
+## Usage
+
+### 1. Add the pg_cron extension image to your Cluster
+
+Define the `pg-cron` extension under the `postgresql.extensions` section of
+your `Cluster` resource. Since pg_cron requires a shared preload library,
+ensure it is also listed in `shared_preload_libraries`. For example:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pg-cron
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    shared_preload_libraries:
+    - pg_cron
+    extensions:
+    - name: pg-cron
+      image:
+        # renovate: suite=trixie-pgdg depName=postgresql-18-cron
+        reference: ghcr.io/cloudnative-pg/pg-cron:1.6.7-18-trixie
+```
+
+### 2. Enable the extension in a database
+
+You can install `pg_cron` in a specific database by creating or updating a
+`Database` resource. For example, to enable it in the `app` database:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: cluster-pg-cron-app
+spec:
+  name: app
+  owner: app
+  cluster:
+    name: cluster-pg-cron
+  extensions:
+  - name: pg_cron
+    # renovate: suite=trixie-pgdg depName=postgresql-18-cron
+    version: '1.6.7'
+```
+
+### 3. Verify installation
+
+Once the database is ready, connect to it with `psql` and run:
+
+```sql
+\dx
+```
+
+You should see `pg_cron` listed among the installed extensions.
+
+## Contributors
+
+This extension is maintained by:
+
+- Erling Kristiansen (@egkristi)
+
+The maintainers are responsible for:
+
+- Monitoring upstream releases and security vulnerabilities.
+- Ensuring compatibility with supported PostgreSQL versions.
+- Reviewing and merging contributions specific to this extension's container
+  image and lifecycle.
+
+---
+
+## Licenses and Copyright
+
+This container image contains software that may be licensed under various
+open-source licenses.
+
+All relevant license and copyright information for the `pg_cron` extension
+and its dependencies are bundled within the image at:
+
+```text
+/licenses/
+```
+
+By using this image, you agree to comply with the terms of the licenses
+contained therein.

--- a/pg-cron/metadata.hcl
+++ b/pg-cron/metadata.hcl
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
+metadata = {
+  name                     = "pg-cron"
+  sql_name                 = "pg_cron"
+  image_name               = "pg-cron"
+  licenses                 = ["PostgreSQL"]
+  shared_preload_libraries = ["pg_cron"]
+  postgresql_parameters    = {}
+  extension_control_path   = []
+  dynamic_library_path     = []
+  ld_library_path          = []
+  bin_path                 = []
+  env                      = {}
+  auto_update_os_libs      = false
+  required_extensions      = []
+  create_extension         = true
+
+  versions = {
+    bookworm = {
+      "18" = {
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-cron
+        package = "1.6.7-2.pgdg12+1"
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-cron extractVersion=^(?<version>\d+\.\d+\.\d+)
+        sql     = "1.6.7"
+      }
+    }
+    trixie = {
+      "18" = {
+        // renovate: suite=trixie-pgdg depName=postgresql-18-cron
+        package = "1.6.7-2.pgdg13+1"
+        // renovate: suite=trixie-pgdg depName=postgresql-18-cron extractVersion=^(?<version>\d+\.\d+\.\d+)
+        sql     = "1.6.7"
+      }
+    }
+  }
+}


### PR DESCRIPTION
pg_cron is a cron-based job scheduler for PostgreSQL that runs inside the database as an extension. It allows scheduling SQL queries and functions to run at specific times or intervals using standard cron syntax.

Closes #207