### PR TITLE
fix: override `PGSSLROOTCERT` in psql container

### DIFF
--- a/postgis/test/check-extension.yaml
+++ b/postgis/test/check-extension.yaml
@@ -9,6 +9,9 @@ spec:
       containers:
       - name: data-test
         env:
+          # Clear the image-baked PGSSLROOTCERT=system so libpq doesn't
+          # try to verify the CNPG self-signed CA against the OS trust store.
+          - name: PGSSLROOTCERT
           - name: EXT_VERSION
             value: ($values.version)
           - name: DB_URI
@@ -16,7 +19,6 @@ spec:
               secretKeyRef:
                 name: (join('-', [$values.name, 'app']))
                 key: uri
-          - name: PGSSLROOTCERT
         # renovate: datasource=docker depName=alpine/psql versioning=docker
         image: alpine/psql:18.4@sha256:51ef105226058360688250fedeac342f020b21d8d3e59dcf9c1fee04f638831c
         command: ['sh', '-c']

--- a/postgis/test/check-extension.yaml
+++ b/postgis/test/check-extension.yaml
@@ -18,7 +18,8 @@ spec:
                 key: uri
           - name: PGSSLROOTCERT
             value: ""
-        image: alpine/psql:latest
+        # renovate: datasource=docker depName=alpine/psql versioning=docker
+        image: alpine/psql:18.4@sha256:51ef105226058360688250fedeac342f020b21d8d3e59dcf9c1fee04f638831c
         command: ['sh', '-c']
         args:
          - |

--- a/postgis/test/check-extension.yaml
+++ b/postgis/test/check-extension.yaml
@@ -17,7 +17,6 @@ spec:
                 name: (join('-', [$values.name, 'app']))
                 key: uri
           - name: PGSSLROOTCERT
-            value: ""
         # renovate: datasource=docker depName=alpine/psql versioning=docker
         image: alpine/psql:18.4@sha256:51ef105226058360688250fedeac342f020b21d8d3e59dcf9c1fee04f638831c
         command: ['sh', '-c']

--- a/postgis/test/check-extension.yaml
+++ b/postgis/test/check-extension.yaml
@@ -16,6 +16,8 @@ spec:
               secretKeyRef:
                 name: (join('-', [$values.name, 'app']))
                 key: uri
+          - name: PGSSLROOTCERT
+            value: ""
         image: alpine/psql:latest
         command: ['sh', '-c']
         args:

--- a/renovate.json
+++ b/renovate.json
@@ -56,11 +56,12 @@
       "customType": "regex",
       "managerFilePatterns": [
         "Taskfile.yml",
-        ".github/workflows/*.yml"
+        ".github/workflows/*.yml",
+        "**/test/*.yaml"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: currentValue=(?<currentValue>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_SHA\\s*:\\s*[\"']?(?<currentDigest>[a-f0-9]+?)[\"']?\\s",
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?(?:[a-zA-Z0-9._/-]+:)?(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
       ]
     },
     {
@@ -71,17 +72,6 @@
       ],
       "matchStrings": [
         "\\/\\/\\s+renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))\\s+\\/\\/\\s+\\+default=[\\\"']?[^:]+?:(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
-      ]
-    },
-    {
-      "description": "updates the test files dependencies",
-      "customType": "regex",
-      "managerFilePatterns": [
-        "test/*.yaml",
-        "**/test/*.yaml"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?[a-z\\/]+:(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
       ]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     ":automergeMinor",
     ":automergeDigest"
   ],
+  "ignorePaths": [],
   "enabledManagers": [
     "github-actions",
     "custom.regex"
@@ -70,6 +71,17 @@
       ],
       "matchStrings": [
         "\\/\\/\\s+renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))\\s+\\/\\/\\s+\\+default=[\\\"']?[^:]+?:(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
+      ]
+    },
+    {
+      "description": "updates the test files dependencies",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "test/*.yaml",
+        "**/test/*.yaml"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?[a-z\\/]+:(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
       ]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -52,7 +52,7 @@
       "datasourceTemplate": "deb"
     },
     {
-      "description": "updates the Taskfile and GitHub Actions workflow dependencies",
+      "description": "updates the Taskfile, test files and GitHub Actions workflow dependencies",
       "customType": "regex",
       "managerFilePatterns": [
         "Taskfile.yml",
@@ -61,7 +61,7 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: currentValue=(?<currentValue>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_SHA\\s*:\\s*[\"']?(?<currentDigest>[a-f0-9]+?)[\"']?\\s",
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?(?:[a-zA-Z0-9._/-]+:)?(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^:]+\\s*:\\s*[\"']?(?:[a-zA-Z0-9._\/-]+:)?(?<currentValue>[^@]+?)(@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
       ]
     },
     {

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -22,7 +22,8 @@ spec:
                 key: uri
           - name: PGSSLROOTCERT
             value: ""
-        image: alpine/psql:latest
+        # renovate: datasource=docker depName=alpine/psql versioning=docker
+        image: alpine/psql:18.4@sha256:51ef105226058360688250fedeac342f020b21d8d3e59dcf9c1fee04f638831c
         command: ['sh', '-c']
         args:
          - |

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -20,6 +20,8 @@ spec:
               secretKeyRef:
                 name: (join('-', [$values.name, 'app']))
                 key: uri
+          - name: PGSSLROOTCERT
+            value: ""
         image: alpine/psql:latest
         command: ['sh', '-c']
         args:

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -9,6 +9,9 @@ spec:
       containers:
       - name: data-test
         env:
+          # Clear the image-baked PGSSLROOTCERT=system so libpq doesn't
+          # try to verify the CNPG self-signed CA against the OS trust store.
+          - name: PGSSLROOTCERT
           - name: EXT_SQL_NAME
             value: ($values.sql_name)
           - name: EXT_VERSION
@@ -20,7 +23,6 @@ spec:
               secretKeyRef:
                 name: (join('-', [$values.name, 'app']))
                 key: uri
-          - name: PGSSLROOTCERT
         # renovate: datasource=docker depName=alpine/psql versioning=docker
         image: alpine/psql:18.4@sha256:51ef105226058360688250fedeac342f020b21d8d3e59dcf9c1fee04f638831c
         command: ['sh', '-c']

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -21,7 +21,6 @@ spec:
                 name: (join('-', [$values.name, 'app']))
                 key: uri
           - name: PGSSLROOTCERT
-            value: ""
         # renovate: datasource=docker depName=alpine/psql versioning=docker
         image: alpine/psql:18.4@sha256:51ef105226058360688250fedeac342f020b21d8d3e59dcf9c1fee04f638831c
         command: ['sh', '-c']


### PR DESCRIPTION
## Summary

Fix the broken Chainsaw `extension-installed` checks after `alpine/psql:latest` started enforcing TLS certificate verification against the system trust store, and prevent the same class of regression in the future. 

Closes #218.

## What changed

- **Override `PGSSLROOTCERT`** in the `extension-installed` Job (generic and PostGIS variants). The upstream image now sets `PGSSLROOTCERT=system` at the container level, which makes libpq implicitly use `sslmode=verify-full` against the OS trust store, and CNPG's self-signed CA isn't in it, so connections fail with `SSL error: certificate verify failed`. Overriding the env var to empty restores the default sslmode for the connectivity probe.
- **Pin `alpine/psql`** to `18.4` by tag + digest in both check-extension Jobs, so a new upstream release can't silently break CI again.
- **Extend the existing Renovate custom manager** to also match `**/test/*.yaml`, so the pinned image is tracked automatically.
- **Override `ignorePaths`** to an empty array, since `config:recommended` pulls in `:ignoreModulesAndTests`, which excludes `**/test/**` and would otherwise hide these files from Renovate.