### PR TITLE
chore: remove PGSSLROOTCERT env var

### DIFF
--- a/postgis/test/check-extension.yaml
+++ b/postgis/test/check-extension.yaml
@@ -9,9 +9,6 @@ spec:
       containers:
       - name: data-test
         env:
-          # Clear the image-baked PGSSLROOTCERT=system so libpq doesn't
-          # try to verify the CNPG self-signed CA against the OS trust store.
-          - name: PGSSLROOTCERT
           - name: EXT_VERSION
             value: ($values.version)
           - name: DB_URI

--- a/test/check-extension.yaml
+++ b/test/check-extension.yaml
@@ -9,9 +9,6 @@ spec:
       containers:
       - name: data-test
         env:
-          # Clear the image-baked PGSSLROOTCERT=system so libpq doesn't
-          # try to verify the CNPG self-signed CA against the OS trust store.
-          - name: PGSSLROOTCERT
           - name: EXT_SQL_NAME
             value: ($values.sql_name)
           - name: EXT_VERSION


### PR DESCRIPTION
`PGSSLROOTCERT` has been removed from the container env vars (see https://github.com/alpine-docker/multi-arch-docker-images/commit/98e93eb4e898f3930ab3378f3b790ba0d4cdc9be), so we don't need to override it anymore.