### PR TITLE
docs: add pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,59 @@
+<!--
+Thanks for contributing to the PostgreSQL Extensions Containers project!
+
+This template is for changes other than adding a new extension (version bumps,
+fixes, shared build/tooling changes, documentation, ...). If you are adding a
+new extension, use the "new_extension" template instead by appending
+`?template=new_extension.md` to the PR creation URL.
+
+Before opening this PR, please read BUILD.md and the general CloudNativePG
+CONTRIBUTING.md:
+https://github.com/cloudnative-pg/governance/blob/main/CONTRIBUTING.md
+-->
+
+## Description
+
+<!-- Explain what this PR does and why. -->
+
+
+
+## Type of change
+
+<!-- Tick the box that applies (put an "x" between the brackets, no spaces). -->
+
+- [ ] Update to an existing extension (version bump, fix)
+- [ ] Shared build infrastructure / tooling change
+- [ ] Documentation only
+- [ ] Other (please describe above)
+
+<!-- If this fixes an open issue, reference it below. -->
+Closes #
+
+---
+
+## Contributor checklist
+
+- [ ] My commits are signed off for [DCO](https://developercertificate.org/)
+      compliance (`git commit -s`).
+- [ ] This PR targets the `main` branch of the upstream repository.
+- [ ] `task checks:all` passes locally.
+- [ ] For changes affecting one or more extensions, the relevant build and E2E
+      tests pass (e.g. `task bake TARGET=<ext>`, `task e2e:test:full TARGET=<ext>`).
+- [ ] Any `// renovate:` comments touched in `metadata.hcl` / `README.md` remain
+      intact (`suite=`, `depName=`, `extractVersion=`).
+- [ ] Documentation (`README.md`, `BUILD.md`, ...) updated where relevant.
+
+---
+
+## Maintainer review checklist
+
+<!-- For maintainers only. -->
+
+- [ ] CI is green for all affected targets / shared changes.
+- [ ] DCO check passes.
+- [ ] Change reviewed for correctness and scope; no unintended targets rebuilt.
+- [ ] `// renovate:` annotations preserved so automated version tracking keeps
+      working.
+- [ ] If shared infrastructure changed, the `_shared` filter in
+      `.github/workflows/bake.yml` was updated when all extensions must rebuild.
+- [ ] PR targets `main` and is ready to merge.

--- a/.github/PULL_REQUEST_TEMPLATE/new_extension.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_extension.md
@@ -1,0 +1,83 @@
+<!--
+Thanks for contributing a new extension to the PostgreSQL Extensions Containers
+project!
+
+Before opening this PR, please make sure you have read:
+  - CONTRIBUTING_NEW_EXTENSION.md (lifecycle for adding an extension)
+  - BUILD.md (build system)
+  - the general CloudNativePG CONTRIBUTING.md:
+    https://github.com/cloudnative-pg/governance/blob/main/CONTRIBUTING.md
+-->
+
+## Extension
+
+<!-- Name of the extension and a short description of what it does and its
+     primary use case. -->
+
+
+
+Closes #<!-- proposal issue id -->
+
+---
+
+## Contributor checklist
+
+<!-- All items must be addressed before requesting a review. -->
+
+- [ ] My commits are signed off for [DCO](https://developercertificate.org/)
+      compliance (`git commit -s`).
+- [ ] Experimental commits have been squashed into a single, well-formed commit.
+- [ ] This PR targets the `main` branch of the upstream repository.
+- [ ] A [New Extension Proposal](https://github.com/cloudnative-pg/postgres-extensions-containers/issues/new/choose)
+      issue exists and is referenced via `Closes #<id>` above.
+- [ ] The commit message follows the format:
+      ``feat: add `<extension-name>` container image``.
+- [ ] The Debian package was verified to exist in the `main` component on both
+      Debian `stable` (`trixie`) and `oldstable` (`bookworm`) via `apt search`.
+- [ ] The extension was scaffolded with `task create-extension NAME=<ext>` and all
+      `TODO` comments in the generated files were resolved.
+- [ ] `metadata.hcl` sets the correct `package` (full Debian version) and, when
+      `create_extension = true`, the matching `sql` (catalog) version.
+- [ ] `create_extension` is set correctly (`false` for PostgreSQL *modules* with
+      no `.control` file — verified with `dpkg -L`).
+- [ ] The `// renovate:` comments in `metadata.hcl` and `README.md` are present
+      and intact (`suite=`, `depName=`, `extractVersion=`).
+- [ ] Every component in the image is covered by a license on the
+      [CNCF Allowlist](https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md);
+      SPDX `licenses` in `metadata.hcl` are accurate.
+- [ ] `task checks:all` passes locally.
+- [ ] Full E2E passes: `task e2e:test:full TARGET="<extension-name>"`.
+- [ ] `README.md` is complete and includes working `Cluster` and `Database`
+      YAML examples.
+- [ ] An entry for the new extension folder was added to
+      [`CODEOWNERS`](../CODEOWNERS) with the component owner's GitHub handle(s).
+- [ ] I confirm my commitment to maintain this extension on behalf of the
+      CloudNativePG community.
+
+---
+
+## Maintainer review checklist
+
+<!-- For maintainers only. Do not merge until every item is verified. -->
+
+- [ ] The linked proposal issue is approved (label `new-extension`) and the
+      `Closes #<id>` reference is correct.
+- [ ] CI is green: the `bake` workflow built the new target for the full
+      `pgVersions × distributions × {amd64, arm64}` matrix.
+- [ ] DCO check passes and history is a single clean commit with the required
+      `feat: add ...` message format.
+- [ ] License compliance reviewed: all redistributed components (extension +
+      transitive/system libs) are on the CNCF Allowlist; SPDX `licenses` match.
+- [ ] `metadata.hcl` reviewed: `package`/`sql` versions, `create_extension`,
+      runtime settings (`shared_preload_libraries`, `*_path`, `env`,
+      `required_extensions`) and behavior flags are correct.
+- [ ] `// renovate:` annotations are intact so automated version PRs will track
+      the package going forward.
+- [ ] `Dockerfile` reviewed: final stage is `FROM scratch`, copies only the
+      expected artifacts, and runs as `65532:65532`.
+- [ ] E2E / Chainsaw tests pass and assert the extension (or module) loads
+      correctly.
+- [ ] `README.md` is clear and its `Cluster`/`Database` examples are valid.
+- [ ] `CODEOWNERS` entry is present and the component owner(s) accept the
+      long-term maintenance commitment.
+- [ ] PR targets `main` and is ready to merge.

--- a/.github/PULL_REQUEST_TEMPLATE/new_extension.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_extension.md
@@ -39,18 +39,19 @@ Closes #<!-- proposal issue id -->
 - [ ] `metadata.hcl` sets the correct `package` (full Debian version) and, when
       `create_extension = true`, the matching `sql` (catalog) version.
 - [ ] `create_extension` is set correctly (`false` for PostgreSQL *modules* with
-      no `.control` file — verified with `dpkg -L`).
-- [ ] The `// renovate:` comments in `metadata.hcl` and `README.md` are present
+      no `.control` file, verified with `dpkg -L`).
+- [ ] The `renovate:` annotations in `metadata.hcl` and `README.md` are present
       and intact (`suite=`, `depName=`, `extractVersion=`).
 - [ ] Every component in the image is covered by a license on the
       [CNCF Allowlist](https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md);
       SPDX `licenses` in `metadata.hcl` are accurate.
 - [ ] `task checks:all` passes locally.
 - [ ] Full E2E passes: `task e2e:test:full TARGET="<extension-name>"`.
-- [ ] `README.md` is complete and includes working `Cluster` and `Database`
-      YAML examples.
+- [ ] `README.md` is complete and includes a working `Cluster` example (plus a
+      `Database` example with `CREATE EXTENSION` when `create_extension = true`).
 - [ ] An entry for the new extension folder was added to
-      [`CODEOWNERS`](../CODEOWNERS) with the component owner's GitHub handle(s).
+      [`CODEOWNERS`](https://github.com/cloudnative-pg/postgres-extensions-containers/blob/main/CODEOWNERS)
+      with the component owner's GitHub handle(s).
 - [ ] I confirm my commitment to maintain this extension on behalf of the
       CloudNativePG community.
 
@@ -71,13 +72,16 @@ Closes #<!-- proposal issue id -->
 - [ ] `metadata.hcl` reviewed: `package`/`sql` versions, `create_extension`,
       runtime settings (`shared_preload_libraries`, `*_path`, `env`,
       `required_extensions`) and behavior flags are correct.
-- [ ] `// renovate:` annotations are intact so automated version PRs will track
+- [ ] `renovate:` annotations are intact so automated version PRs will track
       the package going forward.
-- [ ] `Dockerfile` reviewed: final stage is `FROM scratch`, copies only the
-      expected artifacts, and runs as `65532:65532`.
-- [ ] E2E / Chainsaw tests pass and assert the extension (or module) loads
-      correctly.
-- [ ] `README.md` is clear and its `Cluster`/`Database` examples are valid.
+- [ ] `Dockerfile` reviewed: final stage is `FROM scratch` and contains only the
+      expected artifacts; the `USER 65532:65532` directive matches the nonroot
+      convention.
+- [ ] E2E / Chainsaw tests pass: the extension is registered (when
+      `create_extension = true`), or the Cluster reaches Healthy with the image
+      mounted for preload-only modules.
+- [ ] `README.md` is clear and its `Cluster` example (and `Database` example
+      when `create_extension = true`) are valid.
 - [ ] `CODEOWNERS` entry is present and the component owner(s) accept the
       long-term maintenance commitment.
 - [ ] PR targets `main` and is ready to merge.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,8 @@ https://github.com/cloudnative-pg/governance/blob/main/CONTRIBUTING.md
 - [ ] Documentation only
 - [ ] Other (please describe above)
 
-<!-- If this fixes an open issue, reference it below. -->
-Closes #
+<!-- If this fixes an open issue, reference it here, for example: Closes #123 -->
+
 
 ---
 

--- a/CONTRIBUTING_NEW_EXTENSION.md
+++ b/CONTRIBUTING_NEW_EXTENSION.md
@@ -308,9 +308,8 @@ Submission Requirements:
 > show a chooser for PR templates, so open the PR with this link to preselect
 > it:
 > [Open a new-extension PR](https://github.com/cloudnative-pg/postgres-extensions-containers/compare?expand=1&template=new_extension.md).
-> For any other change (version bumps, fixes, tooling, docs), the
-> [default template](https://github.com/cloudnative-pg/postgres-extensions-containers/compare?expand=1&template=default.md)
-> is applied automatically.
+> For any other change (version bumps, fixes, tooling, docs), the default
+> template is applied automatically, so you can open the PR normally.
 
 By submitting, you confirm your commitment to maintain this extension on behalf
 of the CloudNativePG Community.

--- a/CONTRIBUTING_NEW_EXTENSION.md
+++ b/CONTRIBUTING_NEW_EXTENSION.md
@@ -302,5 +302,15 @@ Submission Requirements:
   file listing the GitHub handles of the component owner(s) for the new
   extension folder.
 
+> [!IMPORTANT]
+> When opening the Pull Request, use the **new extension** template, which
+> includes the full contributor checklist for this lifecycle. GitHub does not
+> show a chooser for PR templates, so open the PR with this link to preselect
+> it:
+> [Open a new-extension PR](https://github.com/cloudnative-pg/postgres-extensions-containers/compare?expand=1&template=new_extension.md).
+> For any other change (version bumps, fixes, tooling, docs), the
+> [default template](https://github.com/cloudnative-pg/postgres-extensions-containers/compare?expand=1&template=default.md)
+> is applied automatically.
+
 By submitting, you confirm your commitment to maintain this extension on behalf
 of the CloudNativePG Community.


### PR DESCRIPTION
## Description

Adds GitHub pull request templates with contributor and maintainer checklists, derived from the lifecycle documented in `CONTRIBUTING_NEW_EXTENSION.md`.

Two templates live under `.github/PULL_REQUEST_TEMPLATE/`:

- **`new_extension.md`** — full lifecycle checklist for adding a new extension: proposal link, package verification on `trixie`/`bookworm`, scaffolding, `metadata.hcl`/renovate/license gates, E2E, README examples, `CODEOWNERS` entry, and the maintenance commitment — plus a maintainer merge checklist (CI matrix, DCO, license compliance, `Dockerfile`/`metadata.hcl` review, Chainsaw tests).
- **`default.md`** — lighter checklist for version bumps, fixes, shared tooling, and documentation changes; applied automatically by GitHub.

Since GitHub does not show a chooser for PR templates, the "Commit and Submit" section of `CONTRIBUTING_NEW_EXTENSION.md` now links to both templates via `?template=` URLs.

## Type of change

- [x] Documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)