### PR TITLE
docs: fix extension name in `timescaledb-oss` README example

### DIFF
--- a/timescaledb-oss/README.md
+++ b/timescaledb-oss/README.md
@@ -21,8 +21,8 @@ of TimescaleDB with [CloudNativePG](https://cloudnative-pg.io/).
 
 ### 1. Add the TimescaleDB extension image to your Cluster
 
-Define the `timescaledb` extension under the `postgresql.extensions` section of
-your `Cluster` resource. For example:
+Define the `timescaledb-oss` extension under the `postgresql.extensions` section
+of your `Cluster` resource. For example:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -44,7 +44,7 @@ spec:
       max_locks_per_transaction: '128'
 
     extensions:
-    - name: timescaledb
+    - name: timescaledb-oss
       image:
         # renovate: suite=trixie-pgdg depName=postgresql-18-timescaledb
         reference: ghcr.io/cloudnative-pg/timescaledb-oss:2.27.1-18-trixie


### PR DESCRIPTION
Fixes the extension name used in the `postgresql.extensions` section of the `Cluster` example in `timescaledb-oss/README.md`.

The example used `timescaledb` instead of the correct extension name `timescaledb-oss` (the metadata `name`). This now matches the convention used by the other extensions (e.g. `pgvector` uses `name: pgvector` under `postgresql.extensions` and `name: vector` under the `Database` resource).

The `Database` resource example and the `\dx` verification text are left unchanged, as they correctly refer to the SQL extension name `timescaledb` (the metadata `sql_name`).

Closes #224