### PR TITLE
feat: use matching distribution and pgMajor version for required extensions

### DIFF
--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -23,8 +23,10 @@ const (
 )
 
 const (
-	AnnotationImageSQLVersion = "io.cloudnativepg.image.sql.version"
-	AnnotationImageBaseName   = "io.cloudnativepg.image.base.name"
+	AnnotationImageSQLVersion  = "io.cloudnativepg.image.sql.version"
+	AnnotationImageBaseName    = "io.cloudnativepg.image.base.name"
+	AnnotationImageBasePgMajor = "io.cloudnativepg.image.base.pgmajor"
+	AnnotationImageBaseOS      = "io.cloudnativepg.image.base.os"
 )
 
 var SupportedDistributions = []string{

--- a/dagger/maintenance/image.go
+++ b/dagger/maintenance/image.go
@@ -82,6 +82,26 @@ func getImageAnnotations(ctx context.Context, imageRef string, username string, 
 	return nil, fmt.Errorf("unsupported media type: %s", head.MediaType)
 }
 
+// parseImageCoordinates extracts the distribution and PostgreSQL major version
+// from the extension image annotations. Every image carries them, and they are
+// used to resolve the images of any required extensions for the same
+// distribution and major.
+func parseImageCoordinates(annotations map[string]string) (string, int, error) {
+	distribution := annotations[AnnotationImageBaseOS]
+	if distribution == "" {
+		return "", 0, fmt.Errorf("missing or empty %q annotation", AnnotationImageBaseOS)
+	}
+
+	rawPgMajor := annotations[AnnotationImageBasePgMajor]
+	pgMajor, err := strconv.Atoi(rawPgMajor)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid %q annotation %q: %w",
+			AnnotationImageBasePgMajor, rawPgMajor, err)
+	}
+
+	return distribution, pgMajor, nil
+}
+
 // getDefaultExtensionImage returns the default extension image for a given extension,
 // resolved from the metadata.
 func getDefaultExtensionImage(metadata *extensionMetadata) (string, error) {

--- a/dagger/maintenance/image_test.go
+++ b/dagger/maintenance/image_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseImageCoordinates(t *testing.T) {
+	tests := []struct {
+		name             string
+		annotations      map[string]string
+		wantDistribution string
+		wantPgMajor      int
+		wantErr          bool
+	}{
+		{
+			name: "valid annotations",
+			annotations: map[string]string{
+				AnnotationImageBaseOS:      "bookworm",
+				AnnotationImageBasePgMajor: "17",
+			},
+			wantDistribution: "bookworm",
+			wantPgMajor:      17,
+		},
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			wantErr:     true,
+		},
+		{
+			name: "missing distribution",
+			annotations: map[string]string{
+				AnnotationImageBasePgMajor: "18",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty distribution",
+			annotations: map[string]string{
+				AnnotationImageBaseOS:      "",
+				AnnotationImageBasePgMajor: "18",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing pgmajor",
+			annotations: map[string]string{
+				AnnotationImageBaseOS: "trixie",
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-numeric pgmajor",
+			annotations: map[string]string{
+				AnnotationImageBaseOS:      "trixie",
+				AnnotationImageBasePgMajor: "trixie",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			distribution, pgMajor, err := parseImageCoordinates(tt.annotations)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if distribution != tt.wantDistribution {
+				t.Errorf("distribution: got %q, want %q", distribution, tt.wantDistribution)
+			}
+			if pgMajor != tt.wantPgMajor {
+				t.Errorf("pgMajor: got %d, want %d", pgMajor, tt.wantPgMajor)
+			}
+		})
+	}
+}

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -186,27 +186,19 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage, AnnotationImageSQLVersion)
 	}
 
-	distribution := annotations[AnnotationImageBaseOS]
-	if distribution == "" {
-		return nil, fmt.Errorf(
-			"extension image %s doesn't have an %q annotation or its value is empty",
-			targetExtensionImage, AnnotationImageBaseOS)
-	}
-
-	pgMajor, err := strconv.Atoi(annotations[AnnotationImageBasePgMajor])
+	distribution, pgMajor, err := parseImageCoordinates(annotations)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"extension image %s doesn't have an %q annotation or its value is not a number",
-			targetExtensionImage, AnnotationImageBasePgMajor)
+		return nil, fmt.Errorf("extension image %s: %w", targetExtensionImage, err)
 	}
 
-	imageLocator := ImageLocator{
+	locator := imageLocator{
 		ExtensionImage: targetExtensionImage,
-		PgMajor:        pgMajor,
 		SQLVersion:     version,
 		Distribution:   distribution,
+		PgMajor:        pgMajor,
 	}
-	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, imageLocator,
+
+	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, locator,
 		registryUsername, registryPassword)
 	if err != nil {
 		return nil, err

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -186,7 +186,21 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage, AnnotationImageSQLVersion)
 	}
 
-	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, targetExtensionImage, version, registryUsername, registryPassword)
+	distribution := annotations[AnnotationImageBaseOS]
+	if distribution == "" {
+		return nil, fmt.Errorf(
+			"extension image %s doesn't have an %q annotation or its value is empty",
+			targetExtensionImage, AnnotationImageBaseOS)
+	}
+
+	pgMajor, err := strconv.Atoi(annotations[AnnotationImageBasePgMajor])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"extension image %s doesn't have an %q annotation or its value is not a number",
+			targetExtensionImage, AnnotationImageBasePgMajor)
+	}
+
+	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, targetExtensionImage, version, distribution, pgMajor, registryUsername, registryPassword)
 	if err != nil {
 		return nil, err
 	}

--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -200,7 +200,14 @@ func (m *Maintenance) GenerateTestingValues(
 			targetExtensionImage, AnnotationImageBasePgMajor)
 	}
 
-	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, targetExtensionImage, version, distribution, pgMajor, registryUsername, registryPassword)
+	imageLocator := ImageLocator{
+		ExtensionImage: targetExtensionImage,
+		PgMajor:        pgMajor,
+		SQLVersion:     version,
+		Distribution:   distribution,
+	}
+	extensionInfos, err := generateTestingValuesExtensions(ctx, source, metadata, imageLocator,
+		registryUsername, registryPassword)
 	if err != nil {
 		return nil, err
 	}

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -37,17 +37,30 @@ type testingExtensionInfo struct {
 	CreateExtension bool
 }
 
-func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directory, metadata *extensionMetadata,
-	extensionImage string, version string, distribution string, pgMajor int, registryUsername string, registryPassword *dagger.Secret) ([]*testingExtensionInfo, error) {
+type ImageLocator struct {
+	ExtensionImage string
+	PgMajor        int
+	SQLVersion     string
+	Distribution   string
+}
+
+func generateTestingValuesExtensions(
+	ctx context.Context,
+	source *dagger.Directory,
+	metadata *extensionMetadata,
+	imageLocator ImageLocator,
+	registryUsername string,
+	registryPassword *dagger.Secret,
+) ([]*testingExtensionInfo, error) {
 	var out []*testingExtensionInfo
-	configuration, err := generateExtensionConfiguration(metadata, extensionImage)
+	configuration, err := generateExtensionConfiguration(metadata, imageLocator.ExtensionImage)
 	if err != nil {
 		return nil, err
 	}
 	out = append(out, &testingExtensionInfo{
 		Configuration:   configuration,
 		SQLName:         metadata.SQLName,
-		Version:         version,
+		Version:         imageLocator.SQLVersion,
 		CreateExtension: metadata.CreateExtension,
 	})
 
@@ -64,7 +77,7 @@ func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directo
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse dependency metadata %q: %w", dep, err)
 		}
-		requiredExtensionImage, err := getExtensionImage(depMetadata, distribution, pgMajor)
+		requiredExtensionImage, err := getExtensionImage(depMetadata, imageLocator.Distribution, imageLocator.PgMajor)
 		if err != nil {
 			return nil, err
 		}

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -38,7 +38,7 @@ type testingExtensionInfo struct {
 }
 
 func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directory, metadata *extensionMetadata,
-	extensionImage string, version string, registryUsername string, registryPassword *dagger.Secret) ([]*testingExtensionInfo, error) {
+	extensionImage string, version string, distribution string, pgMajor int, registryUsername string, registryPassword *dagger.Secret) ([]*testingExtensionInfo, error) {
 	var out []*testingExtensionInfo
 	configuration, err := generateExtensionConfiguration(metadata, extensionImage)
 	if err != nil {
@@ -64,7 +64,11 @@ func generateTestingValuesExtensions(ctx context.Context, source *dagger.Directo
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse dependency metadata %q: %w", dep, err)
 		}
-		depConfiguration, err := generateExtensionConfiguration(depMetadata, "")
+		requiredExtensionImage, err := getExtensionImage(depMetadata, distribution, pgMajor)
+		if err != nil {
+			return nil, err
+		}
+		depConfiguration, err := generateExtensionConfiguration(depMetadata, requiredExtensionImage)
 		if err != nil {
 			return nil, err
 		}

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -37,7 +37,7 @@ type testingExtensionInfo struct {
 	CreateExtension bool
 }
 
-type ImageLocator struct {
+type imageLocator struct {
 	ExtensionImage string
 	PgMajor        int
 	SQLVersion     string
@@ -48,19 +48,19 @@ func generateTestingValuesExtensions(
 	ctx context.Context,
 	source *dagger.Directory,
 	metadata *extensionMetadata,
-	imageLocator ImageLocator,
+	locator imageLocator,
 	registryUsername string,
 	registryPassword *dagger.Secret,
 ) ([]*testingExtensionInfo, error) {
 	var out []*testingExtensionInfo
-	configuration, err := generateExtensionConfiguration(metadata, imageLocator.ExtensionImage)
+	configuration, err := generateExtensionConfiguration(metadata, locator.ExtensionImage)
 	if err != nil {
 		return nil, err
 	}
 	out = append(out, &testingExtensionInfo{
 		Configuration:   configuration,
 		SQLName:         metadata.SQLName,
-		Version:         imageLocator.SQLVersion,
+		Version:         locator.SQLVersion,
 		CreateExtension: metadata.CreateExtension,
 	})
 
@@ -77,7 +77,7 @@ func generateTestingValuesExtensions(
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse dependency metadata %q: %w", dep, err)
 		}
-		requiredExtensionImage, err := getExtensionImage(depMetadata, imageLocator.Distribution, imageLocator.PgMajor)
+		requiredExtensionImage, err := getExtensionImage(depMetadata, locator.Distribution, locator.PgMajor)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes possibly diverging OS and PostgreSQL versions for extensions one depends on.

During tests of a `bookworm-pg17` image the workflow would use the `trixie-pg18` image of the extensions dependency (see `getDefaultExtensionImage`). This could present problems, in my case incompatible libc requirements.

Closes #232 