### PR TITLE
docs: list externally-maintained extensions (pg_search/ParadeDB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Extensions are provided only for the OS versions already built by the
 [`cloudnative-pg/postgres-containers`](https://github.com/cloudnative-pg/postgres-containers) project,
 specifically Debian `stable` and `oldstable`.
 
+### Externally Maintained Extensions
+
+The following extensions are **built with this project's tooling and naming
+conventions but distributed independently** by their respective maintainers —
+typically because their license is not on the
+[CNCF Allowlist](https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md)
+and therefore cannot be hosted in this repository
+(see [Extension Requirements](#extension-requirements)). They are listed here
+purely for **discoverability**: the CloudNativePG project does **not** build,
+host, audit, or maintain these images, and their owners are solely responsible
+for them.
+
+| Extension | Description | Project URL | Image | Maintained by |
+| :--- | :--- | :--- | :--- | :--- |
+| **pg_search** | Elastic-quality full-text search for PostgreSQL (AGPL-3.0) | [github.com/paradedb/paradedb](https://github.com/paradedb/paradedb) | [`paradedb/paradedb-extension`](https://hub.docker.com/r/paradedb/paradedb-extension) | [ParadeDB](https://paradedb.com) (@isaacvando, @philippemnoel, @rebasedming) |
+
 ---
 
 ## Contribution and Maintenance Policy

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ for them.
 
 | Extension | Description | Project URL | Image | Maintained by |
 | :--- | :--- | :--- | :--- | :--- |
-| **pg_search** | Elastic-quality full-text search for PostgreSQL (AGPL-3.0) | [github.com/paradedb/paradedb](https://github.com/paradedb/paradedb) | [`paradedb/paradedb-extension`](https://hub.docker.com/r/paradedb/paradedb-extension) | [ParadeDB](https://paradedb.com) (@isaacvando, @philippemnoel, @rebasedming) |
+| **pg_search** | Elastic-quality full-text search for PostgreSQL | [github.com/paradedb/paradedb](https://github.com/paradedb/paradedb) | [`paradedb/paradedb-extension`](https://hub.docker.com/r/paradedb/paradedb-extension) | [ParadeDB](https://paradedb.com) (@philippemnoel, @rebasedming, @isaacvando) |
 
 ---
 


### PR DESCRIPTION
## Summary

Hi everyone. Philippe here from ParadeDB/pg_search. We are a PostgreSQL extension for full-text and vector search in Postgres. We are a commercial, open-source project and license under AGPL-3.0 to protect ourselves from AWS and other hyperscalers.

We opened #204, and following Gabriele's feedback we started publishing our own `cnpg-extensions-containers` image, to https://hub.docker.com/r/paradedb/paradedb-extension. I understand our license prohibits being listed in this repo, but I was wondering if the project was willing to document a list of externally-supported extension containers, like ours? This is a slightly self-interested request, in that it will help with our discoverability, but I also expect it could be beneficial for other such extensions (for instance, Timescale's non-permissive extension, or even closed-source ones from hyperscalers). What do you think?

We used the build tooling from this repository. For context:

- **Image:** [`paradedb/paradedb-extension`](https://hub.docker.com/r/paradedb/paradedb-extension) (e.g. `paradedb/paradedb-extension:0.24.0-18-trixie`)
- **Source:** https://github.com/paradedb/paradedb

Happy to adjust the wording as well. Lmk and thank you!