### PR TITLE
ci: pull dagger runner image from ghcr.io

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -20,6 +20,11 @@ jobs:
   change-triage:
     name: Check changed files
     runs-on: ubuntu-24.04
+    permissions:
+      packages: read
+    env:
+      # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+      DAGGER_VERSION: 0.21.7
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix}}
     steps:
@@ -28,12 +33,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Fetch valid targets
         id: get-targets
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         env:
-          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.21.7
+          # Provision the engine from GHCR instead of registry.dagger.io, whose
+          # Fly.io-hosted front intermittently times out from GitHub runners.
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: docker-image://ghcr.io/dagger/engine:v${{ env.DAGGER_VERSION }}
         with:
           version: ${{ env.DAGGER_VERSION }}
           verb: call

--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -126,6 +126,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ jobs:
   unit-test:
     name: Go unit tests
     runs-on: ubuntu-24.04
+    permissions:
+      packages: read
+    env:
+      # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+      DAGGER_VERSION: 0.21.7
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -33,11 +38,19 @@ jobs:
           go-version-file: dagger/maintenance/go.mod
           cache-dependency-path: dagger/maintenance/go.sum
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate the Dagger client
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         env:
-          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.21.7
+          # Provision the engine from GHCR instead of registry.dagger.io, whose
+          # Fly.io-hosted front intermittently times out from GitHub runners.
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: docker-image://ghcr.io/dagger/engine:v${{ env.DAGGER_VERSION }}
         with:
           version: ${{ env.DAGGER_VERSION }}
           verb: develop

--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -18,8 +18,12 @@ jobs:
   update-catalogs:
     name: Updating catalogs
     runs-on: ubuntu-24.04
+    env:
+      # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+      DAGGER_VERSION: 0.21.7
     permissions:
       id-token: write
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -34,12 +38,20 @@ jobs:
           token: ${{ secrets.REPO_GHA_PAT }}
           ref: main
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update catalogs
         id: update-extension-catalogs
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         env:
-          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.21.7
+          # Provision the engine from GHCR instead of registry.dagger.io, whose
+          # Fly.io-hosted front intermittently times out from GitHub runners.
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: docker-image://ghcr.io/dagger/engine:v${{ env.DAGGER_VERSION }}
         with:
           version: ${{ env.DAGGER_VERSION }}
           verb: call

--- a/.github/workflows/update_os_libraries.yml
+++ b/.github/workflows/update_os_libraries.yml
@@ -15,6 +15,11 @@ jobs:
   fetch-extensions:
     name: Fetch target extensions
     runs-on: ubuntu-24.04
+    permissions:
+      packages: read
+    env:
+      # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+      DAGGER_VERSION: 0.21.7
     outputs:
       extensions: ${{ steps.get-extensions.outputs.extensions }}
     steps:
@@ -23,12 +28,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Fetch extensions
         id: get-extensions-dagger
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         env:
-          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.21.7
+          # Provision the engine from GHCR instead of registry.dagger.io, whose
+          # Fly.io-hosted front intermittently times out from GitHub runners.
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: docker-image://ghcr.io/dagger/engine:v${{ env.DAGGER_VERSION }}
         with:
           version: ${{ env.DAGGER_VERSION }}
           verb: call
@@ -46,6 +59,11 @@ jobs:
   update-extension-os-libs:
     name: Update OS libs for ${{ matrix.extension }}
     runs-on: ubuntu-24.04
+    permissions:
+      packages: read
+    env:
+      # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+      DAGGER_VERSION: 0.21.7
     needs:
       - fetch-extensions
     strategy:
@@ -65,8 +83,9 @@ jobs:
       - name: Update OS libs for ${{ matrix.extension }}
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         env:
-          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.21.7
+          # Provision the engine from GHCR instead of registry.dagger.io, whose
+          # Fly.io-hosted front intermittently times out from GitHub runners.
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: docker-image://ghcr.io/dagger/engine:v${{ env.DAGGER_VERSION }}
         with:
           version: ${{ env.DAGGER_VERSION }}
           verb: call

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -211,7 +211,7 @@ tasks:
     cmds:
       - >
         docker run -d -v /var/lib/dagger --name {{ .DAGGER_ENGINE_NAME }} --restart always --network {{ .E2E_NETWORK }}
-        --privileged registry.dagger.io/engine:{{ .DAGGER_ENGINE_VERSION }}
+        --privileged ghcr.io/dagger/engine:{{ .DAGGER_ENGINE_VERSION }}
     status:
       - test "$(docker inspect -f {{`'{{json .State.Running}}'`}} {{ .DAGGER_ENGINE_NAME }})" == "true"
 


### PR DESCRIPTION
## Description

Test pulling the dagger runner from `ghcr.io` instead of `registry.dagger.io` to avoid
reoccurring failures like:
```
start engine: new client: context deadline exceeded
```
or 
```
Get "https://registry.dagger.io/v2/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```



## Type of change

<!-- Tick the box that applies (put an "x" between the brackets, no spaces). -->

- [ ] Update to an existing extension (version bump, fix)
- [X] Shared build infrastructure / tooling change
- [ ] Documentation only
- [ ] Other (please describe above)

<!-- If this fixes an open issue, reference it here, for example: Closes #123 -->


---

## Contributor checklist

- [ ] My commits are signed off for [DCO](https://developercertificate.org/)
      compliance (`git commit -s`).
- [ ] This PR targets the `main` branch of the upstream repository.
- [ ] `task checks:all` passes locally.
- [ ] For changes affecting one or more extensions, the relevant build and E2E
      tests pass (e.g. `task bake TARGET=<ext>`, `task e2e:test:full TARGET=<ext>`).
- [ ] Any `// renovate:` comments touched in `metadata.hcl` / `README.md` remain
      intact (`suite=`, `depName=`, `extractVersion=`).
- [ ] Documentation (`README.md`, `BUILD.md`, ...) updated where relevant.

---

## Maintainer review checklist

<!-- For maintainers only. -->

- [ ] CI is green for all affected targets / shared changes.
- [ ] DCO check passes.
- [ ] Change reviewed for correctness and scope; no unintended targets rebuilt.
- [ ] `// renovate:` annotations preserved so automated version tracking keeps
      working.
- [ ] If shared infrastructure changed, the `_shared` filter in
      `.github/workflows/bake.yml` was updated when all extensions must rebuild.
- [ ] PR targets `main` and is ready to merge.
