### PR TITLE
feat: add `pg-jsonschema` container image

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,6 @@
 
 # wal2json
 /wal2json/ @cloudnative-pg/maintainers @NiccoloFei @solidDoWant
+
+# pg_jsonschema
+/pg-jsonschema/ @elohmeier @cloudnative-pg/maintainers @NiccoloFei

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ from a trusted, auditable repository
 | :--- | :--- | :--- | :--- |
 | **[pgAudit](pgaudit)** | PostgreSQL audit extension | [github.com/pgaudit/pgaudit](https://github.com/pgaudit/pgaudit) | CNPG maintainers |
 | **[pg_crash](pg-crash)** | **Disruptive** fault injection and chaos engineering extension | [github.com/cybertec-postgresql/pg_crash](https://github.com/cybertec-postgresql/pg_crash) | CNPG maintainers |
+| **[pg_jsonschema](pg-jsonschema)** | JSON Schema validation for PostgreSQL `json` and `jsonb` data | [github.com/supabase/pg_jsonschema](https://github.com/supabase/pg_jsonschema) | @elohmeier |
 | **[pgvector](pgvector)** | Vector similarity search for PostgreSQL | [github.com/pgvector/pgvector](https://github.com/pgvector/pgvector) | CNPG maintainers |
 | **[PostGIS](postgis)** | Geospatial database extension for PostgreSQL | [postgis.net/](https://postgis.net/) | CNPG maintainers |
 | **[TimescaleDB Apache-2 Edition](timescaledb-oss)** | Time-series database for PostgreSQL (open source version) | [github.com/timescale/timescaledb/](https://github.com/timescale/timescaledb/) | @shusaan |
@@ -208,4 +209,3 @@ list of compatible extension images for PostgreSQL 18+ versions.
   project](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs-extensions).
 - **Naming Convention:** These are based on the `minimal` catalog and use the
   `catalog-minimal` prefix (e.g., `catalog-minimal-trixie.yaml`).
-

--- a/pg-jsonschema/Dockerfile
+++ b/pg-jsonschema/Dockerfile
@@ -1,0 +1,41 @@
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+FROM $BASE AS builder
+
+ARG PG_MAJOR
+ARG EXT_VERSION
+ARG TARGETARCH
+
+USER 0
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) arch="amd64" ;; \
+        arm64) arch="arm64" ;; \
+        *) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/pg_jsonschema.deb \
+        "https://github.com/supabase/pg_jsonschema/releases/download/v${EXT_VERSION}/pg_jsonschema-v${EXT_VERSION}-pg${PG_MAJOR}-${arch}-linux-gnu.deb"; \
+    dpkg -i /tmp/pg_jsonschema.deb; \
+    rm /tmp/pg_jsonschema.deb; \
+    curl -fsSL -o /licenses/pg_jsonschema/LICENSE \
+        --create-dirs \
+        "https://raw.githubusercontent.com/supabase/pg_jsonschema/v${EXT_VERSION}/LICENSE"
+
+FROM scratch
+ARG PG_MAJOR
+
+# Licenses
+COPY --from=builder /licenses /licenses/
+
+# Libraries
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/pg_jsonschema.so /lib/
+
+# Share
+COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/pg_jsonschema* /share/extension/
+
+USER 65532:65532

--- a/pg-jsonschema/README.md
+++ b/pg-jsonschema/README.md
@@ -1,0 +1,83 @@
+# pg_jsonschema
+
+[pg_jsonschema](https://github.com/supabase/pg_jsonschema) is a PostgreSQL
+extension that adds JSON Schema validation for `json` and `jsonb` data.
+
+This image provides a convenient way to deploy and manage `pg_jsonschema` with
+[CloudNativePG](https://cloudnative-pg.io/).
+
+The image installs the official `.deb` packages published in Supabase's
+`pg_jsonschema` GitHub releases.
+
+## Usage
+
+### 1. Add the extension image to your Cluster
+
+Define the `pg-jsonschema` extension under the `postgresql.extensions` section
+of your `Cluster` resource. For example:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pg-jsonschema
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    extensions:
+    - name: pg-jsonschema
+      image:
+        # renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+        reference: ghcr.io/cloudnative-pg/pg-jsonschema:0.3.4-18-trixie
+```
+
+### 2. Enable the extension in a database
+
+Create or update a `Database` resource to install the extension in a specific
+database:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: cluster-pg-jsonschema-app
+spec:
+  name: app
+  owner: app
+  cluster:
+    name: cluster-pg-jsonschema
+  extensions:
+  - name: pg_jsonschema
+    # renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+    version: "0.3.4"
+```
+
+### 3. Verify installation
+
+Once the database is ready, connect to it with `psql` and run:
+
+```sql
+\dx
+```
+
+You should see `pg_jsonschema` listed among the installed extensions.
+
+## Contributors
+
+This extension is maintained by:
+
+- @elohmeier
+
+## Licenses and Copyright
+
+The `pg_jsonschema` extension is licensed under Apache-2.0. License information
+is bundled in the image under:
+
+```text
+/licenses/
+```

--- a/pg-jsonschema/metadata.hcl
+++ b/pg-jsonschema/metadata.hcl
@@ -1,0 +1,35 @@
+metadata = {
+  name                     = "pg-jsonschema"
+  sql_name                 = "pg_jsonschema"
+  image_name               = "pg-jsonschema"
+  licenses                 = ["Apache-2.0"]
+  shared_preload_libraries = []
+  postgresql_parameters    = {}
+  extension_control_path   = []
+  dynamic_library_path     = []
+  ld_library_path          = []
+  bin_path                 = []
+  env                      = {}
+  auto_update_os_libs      = false
+  required_extensions      = []
+  create_extension         = true
+
+  versions = {
+    bookworm = {
+      "18" = {
+        // renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+        package = "0.3.4"
+        // renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+        sql     = "0.3.4"
+      }
+    }
+    trixie = {
+      "18" = {
+        // renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+        package = "0.3.4"
+        // renovate: datasource=github-tags depName=supabase/pg_jsonschema versioning=semver extractVersion=^v(?<version>.*)$
+        sql     = "0.3.4"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the PostgreSQL Extensions Containers project!

This template is for changes other than adding a new extension (version bumps,
fixes, shared build/tooling changes, documentation, ...). If you are adding a
new extension, use the "new_extension" template instead by appending
`?template=new_extension.md` to the PR creation URL.

Before opening this PR, please read BUILD.md and the general CloudNativePG
CONTRIBUTING.md:
https://github.com/cloudnative-pg/governance/blob/main/CONTRIBUTING.md
-->

## Description

This PR adds a `pg-jsonschema` extension container image for PostgreSQL 18 on
Debian `bookworm` and `trixie`.

`pg_jsonschema` provides JSON Schema validation for PostgreSQL `json` and
`jsonb` data.

Packaging note: `pg_jsonschema` is currently not available through the PG 18
`bookworm` or `trixie` base-image apt sources. This image intentionally
installs Supabase's official GitHub release `.deb` assets from:

https://github.com/supabase/pg_jsonschema/releases/tag/v0.3.4

The package contains `pg_jsonschema.control`, `pg_jsonschema--0.3.4.sql`, and
`pg_jsonschema.so`. The final image remains `FROM scratch` and copies only the
extension artifacts plus the upstream Apache-2.0 license.

## Type of change

<!-- Tick the box that applies (put an "x" between the brackets, no spaces). -->

- [ ] Update to an existing extension (version bump, fix)
- [ ] Shared build infrastructure / tooling change
- [ ] Documentation only
- [x] Other (please describe above)

<!-- If this fixes an open issue, reference it here, for example: Closes #123 -->

Closes #117. Follow-up to https://github.com/cloudnative-pg/postgres-extensions-containers/pull/103.

---

## Contributor checklist

- [x] My commits are signed off for [DCO](https://developercertificate.org/)
      compliance (`git commit -s`).
- [x] This PR targets the `main` branch of the upstream repository.
- [ ] `task checks:all` passes locally.
      Not run locally.
- [ ] For changes affecting one or more extensions, the relevant build and E2E
      tests pass (e.g. `task bake TARGET=<ext>`, `task e2e:test:full TARGET=<ext>`).
      `task bake TARGET=pg-jsonschema` passed locally; full E2E was not run
      locally.
- [x] Any `// renovate:` comments touched in `metadata.hcl` / `README.md` remain
      intact (`suite=`, `depName=`, `extractVersion=`).
      This PR uses GitHub tag-based Renovate annotations for
      `supabase/pg_jsonschema`.
- [x] Documentation (`README.md`, `BUILD.md`, ...) updated where relevant.

---

## Maintainer review checklist

<!-- For maintainers only. -->

- [ ] CI is green for all affected targets / shared changes.
- [ ] DCO check passes.
- [ ] Change reviewed for correctness and scope; no unintended targets rebuilt.
- [ ] `// renovate:` annotations preserved so automated version tracking keeps
      working.
- [ ] If shared infrastructure changed, the `_shared` filter in
      `.github/workflows/bake.yml` was updated when all extensions must rebuild.
- [ ] PR targets `main` and is ready to merge.
