### PR TITLE
chore: quote CNPG_RELEASE_DEFAULT

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,7 @@ vars:
   K8S_VERSION: '{{ regexReplaceAll "^v([0-9.]+).*" .KIND_NODE_VERSION "$1" }}'
   KIND_CLUSTER_NAME: pg-extensions-{{ .K8S_VERSION }}
   # renovate: datasource=github-tags depName=cloudnative-pg/cloudnative-pg versioning=semver-coerced extractVersion=^v(?<version>\d+\.\d+)\.\d+$
-  CNPG_RELEASE_DEFAULT: 1.30
+  CNPG_RELEASE_DEFAULT: '1.30'
 
 tasks:
   default:


### PR DESCRIPTION
An unquoted 1.30 is parsed as a float, not a string, so it gets normalized as 1.3 which makes `e2e:setup-env` fail because `cloudnative-pg/artifacts/release-1.3/manifests/operator-manifest.yaml` doesn't exist.

Closes #281 