### PR TITLE
chore: expand account names in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,13 +2,13 @@
 # responsible for code in a repository. For details, please refer to
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @cloudnative-pg/maintainers @NiccoloFei
+* @leonardoce @mnencia @gbartolini @fcanovai @armru @NiccoloFei @GabriFedi97
 
 # TimescaleDB (OSS version)
-/timescaledb-oss/ @shusaan @cloudnative-pg/maintainers @NiccoloFei
+/timescaledb-oss/ @shusaan
 
 # wal2json
-/wal2json/ @cloudnative-pg/maintainers @NiccoloFei @solidDoWant
+/wal2json/ @solidDoWant
 
 # pg-ivm
-/pg-ivm/ @shusaan @cloudnative-pg/maintainers @NiccoloFei
+/pg-ivm/ @shusaan


### PR DESCRIPTION
Add GabriFedi97 as CODEOWNER for the repository.

Also, limit the requirement to review an extension to the owner.

Closes #287