### PR TITLE
fix(PostGIS): strip `$libdir/` prefix from extension SQL scripts

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -16,6 +16,14 @@ RUN set -eux && \
 		"postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR}=${EXT_VERSION}" \
 		"postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR}-scripts=${EXT_VERSION}"
 
+# Strip the "$libdir/" prefix from LOAD statements in the extension upgrade
+# scripts: with imageVolume-mounted extensions there is no $libdir to expand,
+# and PostgreSQL 18+ fails the LOAD during CREATE/ALTER EXTENSION otherwise.
+# dynamic_library_path already resolves the bare module name.
+RUN sed -i "s/\$libdir\///g" \
+	/usr/share/postgresql/${PG_MAJOR}/extension/postgis*.sql \
+	/usr/share/postgresql/${PG_MAJOR}/extension/address_standardizer*.sql
+
 # Gather PostGIS system libraries and their licenses
 RUN mkdir -p /system /licenses && \
 	# Get libraries

--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -16,13 +16,17 @@ RUN set -eux && \
 		"postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR}=${EXT_VERSION}" \
 		"postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR}-scripts=${EXT_VERSION}"
 
-# Strip the "$libdir/" prefix from LOAD statements in the extension upgrade
-# scripts: with imageVolume-mounted extensions there is no $libdir to expand,
-# and PostgreSQL 18+ fails the LOAD during CREATE/ALTER EXTENSION otherwise.
+# Strip the "$libdir/" prefix from LOAD and CREATE FUNCTION ... AS statements
+# in the extension and contrib scripts: with imageVolume-mounted extensions
+# there is no $libdir to expand, and PostgreSQL 18+ fails to resolve it during
+# CREATE/ALTER EXTENSION otherwise.
 # dynamic_library_path already resolves the bare module name.
-RUN sed -i "s/\$libdir\///g" \
+# Only strip right after an opening quote, so the pattern can't accidentally
+# touch unrelated text.
+RUN sed -i "s/'\$libdir\//'/g" \
 	/usr/share/postgresql/${PG_MAJOR}/extension/postgis*.sql \
-	/usr/share/postgresql/${PG_MAJOR}/extension/address_standardizer*.sql
+	/usr/share/postgresql/${PG_MAJOR}/extension/address_standardizer*.sql \
+	/usr/share/postgresql/${PG_MAJOR}/contrib/postgis*/*.sql
 
 # Gather PostGIS system libraries and their licenses
 RUN mkdir -p /system /licenses && \


### PR DESCRIPTION
`ALTER EXTENSION UPDATE` fails with `"could not access file "$libdir/postgis-3": No such file or directory"` because the PGDG-packaged `postgis`/`address_standardizer` SQL scripts hardcode `$libdir/<module>` both in `LOAD` statements and in `AS` function definitions, but with `imageVolume`-mounted extensions there is no `$libdir` to expand. `dynamic_library_path` already resolves the bare module name, so the `$libdir/` prefix is stripped from all PostGIS install and upgrade scripts at build time.

If successful, we should fix this upstream, either in the Debian packaging project or in PostGIS directly.

Closes #256

Co-Authored-By: Claude