### PR TITLE
feat: add `pgrouting` container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ from a trusted, auditable repository
 | **[wal2json](wal2json)** | Logical decoding output plugin for PostgreSQL | [github.com/eulerto/wal2json](https://github.com/eulerto/wal2json) | @solidDoWant |
 
 > [!NOTE]
-> PostGIS and PgRouting are licensed under GPL-2.0, which is not on the CNCF Allowlist.
+> PostGIS and pgRouting are licensed under GPL-2.0, which is not on the CNCF Allowlist.
 > They predate this policy; the maintainers are filing a CNCF license exception
 > for them. They are not a precedent for accepting further non-Allowlisted
 > extensions.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ from a trusted, auditable repository
 | **[wal2json](wal2json)** | Logical decoding output plugin for PostgreSQL | [github.com/eulerto/wal2json](https://github.com/eulerto/wal2json) | @solidDoWant |
 
 > [!NOTE]
-> PostGIS is licensed under GPL-2.0, which is not on the CNCF Allowlist. It
-> predates this policy; the maintainers are filing a CNCF license exception
-> for it. PostGIS is not a precedent for accepting further non-Allowlisted
+> PostGIS and PgRouting are licensed under GPL-2.0, which is not on the CNCF Allowlist.
+> They predate this policy; the maintainers are filing a CNCF license exception
+> for them. They are not a precedent for accepting further non-Allowlisted
 > extensions.
 
 Extensions are provided only for the OS versions already built by the

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ from a trusted, auditable repository
 | **[pgAudit](pgaudit)** | PostgreSQL audit extension | [github.com/pgaudit/pgaudit](https://github.com/pgaudit/pgaudit) | CNPG maintainers |
 | **[pg_crash](pg-crash)** | **Disruptive** fault injection and chaos engineering extension | [github.com/cybertec-postgresql/pg_crash](https://github.com/cybertec-postgresql/pg_crash) | CNPG maintainers |
 | **[pg_ivm](pg-ivm)** | Incremental View Maintenance for PostgreSQL | [github.com/sraoss/pg_ivm](https://github.com/sraoss/pg_ivm) | @shusaan |
-| **[pgRouting](pgrouting)** | Geospatial routing and network analysis for PostgreSQL/PostGIS | [pgrouting.org](https://pgrouting.org/) | |
+| **[pgRouting](pgrouting)** | Geospatial routing and network analysis for PostgreSQL/PostGIS | [pgrouting.org](https://pgrouting.org/) | CNPG maintainers |
 | **[pgvector](pgvector)** | Vector similarity search for PostgreSQL | [github.com/pgvector/pgvector](https://github.com/pgvector/pgvector) | CNPG maintainers |
 | **[PostGIS](postgis)** | Geospatial database extension for PostgreSQL | [postgis.net/](https://postgis.net/) | CNPG maintainers |
 | **[TimescaleDB Apache-2 Edition](timescaledb-oss)** | Time-series database for PostgreSQL (open source version) | [github.com/timescale/timescaledb/](https://github.com/timescale/timescaledb/) | @shusaan |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ from a trusted, auditable repository
 | **[pgAudit](pgaudit)** | PostgreSQL audit extension | [github.com/pgaudit/pgaudit](https://github.com/pgaudit/pgaudit) | CNPG maintainers |
 | **[pg_crash](pg-crash)** | **Disruptive** fault injection and chaos engineering extension | [github.com/cybertec-postgresql/pg_crash](https://github.com/cybertec-postgresql/pg_crash) | CNPG maintainers |
 | **[pg_ivm](pg-ivm)** | Incremental View Maintenance for PostgreSQL | [github.com/sraoss/pg_ivm](https://github.com/sraoss/pg_ivm) | @shusaan |
+| **[pgRouting](pgrouting)** | Geospatial routing and network analysis for PostgreSQL/PostGIS | [pgrouting.org](https://pgrouting.org/) | |
 | **[pgvector](pgvector)** | Vector similarity search for PostgreSQL | [github.com/pgvector/pgvector](https://github.com/pgvector/pgvector) | CNPG maintainers |
 | **[PostGIS](postgis)** | Geospatial database extension for PostgreSQL | [postgis.net/](https://postgis.net/) | CNPG maintainers |
 | **[TimescaleDB Apache-2 Edition](timescaledb-oss)** | Time-series database for PostgreSQL (open source version) | [github.com/timescale/timescaledb/](https://github.com/timescale/timescaledb/) | @shusaan |

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -45,6 +45,8 @@ repository:
         comment: GitHub packages for the pgvector extension image
       - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/postgis-extension
         comment: GitHub packages for the PostGIS extension image
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/pgrouting
+        comment: GitHub packages for the pgrouting extension image
       - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/pgaudit
         comment: GitHub packages for the pgaudit extension image
       - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/pg-ivm

--- a/pgrouting/Dockerfile
+++ b/pgrouting/Dockerfile
@@ -6,76 +6,22 @@ ARG EXT_VERSION
 
 USER 0
 
-RUN set -eux && \
-	# Initial system libraries
-	ldconfig -p | awk '{print $NF}' | grep '^/' | sort | uniq > /tmp/base-image-libs.out && \
-	# Install pgRouting
-	apt-get update && \
+RUN apt-get update && \
 	apt-get install -y --no-install-recommends \
-		"postgresql-${PG_MAJOR}-pgrouting=${EXT_VERSION}" \
-		"postgresql-${PG_MAJOR}-pgrouting-scripts=${EXT_VERSION}"
-
-# Strip the "$libdir/" prefix from LOAD and CREATE FUNCTION ... AS statements
-# in the extension scripts: with imageVolume-mounted extensions
-# there is no $libdir to expand, and PostgreSQL 18+ fails to resolve it during
-# CREATE/ALTER EXTENSION otherwise.
-# dynamic_library_path already resolves the bare module name.
-# Only strip right after an opening quote, so the pattern can't accidentally
-# touch unrelated text.
-RUN sed -i "s/'\$libdir\//'/g" \
-	/usr/share/postgresql/${PG_MAJOR}/extension/pgrouting*.sql
-
-# Gather pgRouting system libraries and their licenses
-RUN mkdir -p /system /licenses && \
-	# Get libraries
-	ldd /usr/lib/postgresql/${PG_MAJOR}/lib/libpgrouting*.so \
-		| awk '{print $3}' | grep '^/' | sort | uniq > /tmp/all-deps.out && \
-	# Extract all the libs that aren't already part of the base image
-	comm -13 /tmp/base-image-libs.out /tmp/all-deps.out > /tmp/libraries.out && \
-	while read -r lib; do \
-		resolved=$(readlink -f "$lib"); \
-		dir=$(dirname "$lib"); \
-		base=$(basename "$lib"); \
-		# Copy the real file
-		cp -a "$resolved" /system/; \
-		# Reconstruct all its symlinks
-		for file in "$dir"/"${base%.so*}.so"*; do \
-			[ -e "$file" ] || continue; \
-			# If it's a symlink and it resolves to the same real file, we reconstruct it
-			if [ -L "$file" ] && [ "$(readlink -f "$file")" = "$resolved" ]; then \
-				ln -sf "$(basename "$resolved")" "/system/$(basename "$file")"; \
-			fi; \
-		done; \
-	done < /tmp/libraries.out && \
-	# Get licenses
-	for lib in $(find /system -maxdepth 1 -type f -name '*.so*'); do \
-		# Get the name of the pkg that installed the library
-		pkg=$(dpkg -S "$(basename "$lib")" | grep -v "diversion by" | awk -F: '/:/{print $1; exit}'); \
-		[ -z "$pkg" ] && continue; \
-		mkdir -p "/licenses/$pkg" && cp -a "/usr/share/doc/$pkg/copyright" "/licenses/$pkg/copyright"; \
-	done
-
+      "postgresql-${PG_MAJOR}-pgrouting=${EXT_VERSION}" \
+      "postgresql-${PG_MAJOR}-pgrouting-scripts=${EXT_VERSION}"
 
 FROM scratch
 ARG PG_MAJOR
 
 # Licenses
-COPY --from=builder /licenses /licenses/
 COPY --from=builder /usr/share/doc/postgresql-${PG_MAJOR}-pgrouting/copyright /licenses/postgresql-${PG_MAJOR}-pgrouting/
 
 # Libraries
-COPY --from=builder \
-	/usr/lib/postgresql/${PG_MAJOR}/lib/libpgrouting* \
-	/lib/
-
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/libpgrouting* /lib/
 COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/bitcode/ /lib/bitcode/
 
 # Share
-COPY --from=builder \
-	/usr/share/postgresql/${PG_MAJOR}/extension/pgrouting* \
-	/share/extension/
-
-# System libs
-COPY --from=builder /system /system/
+COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/pgrouting* /share/extension/
 
 USER 65532:65532

--- a/pgrouting/Dockerfile
+++ b/pgrouting/Dockerfile
@@ -1,0 +1,81 @@
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+FROM $BASE AS builder
+
+ARG PG_MAJOR
+ARG EXT_VERSION
+
+USER 0
+
+RUN set -eux && \
+	# Initial system libraries
+	ldconfig -p | awk '{print $NF}' | grep '^/' | sort | uniq > /tmp/base-image-libs.out && \
+	# Install pgRouting
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
+		"postgresql-${PG_MAJOR}-pgrouting=${EXT_VERSION}" \
+		"postgresql-${PG_MAJOR}-pgrouting-scripts=${EXT_VERSION}"
+
+# Strip the "$libdir/" prefix from LOAD and CREATE FUNCTION ... AS statements
+# in the extension scripts: with imageVolume-mounted extensions
+# there is no $libdir to expand, and PostgreSQL 18+ fails to resolve it during
+# CREATE/ALTER EXTENSION otherwise.
+# dynamic_library_path already resolves the bare module name.
+# Only strip right after an opening quote, so the pattern can't accidentally
+# touch unrelated text.
+RUN sed -i "s/'\$libdir\//'/g" \
+	/usr/share/postgresql/${PG_MAJOR}/extension/pgrouting*.sql
+
+# Gather pgRouting system libraries and their licenses
+RUN mkdir -p /system /licenses && \
+	# Get libraries
+	ldd /usr/lib/postgresql/${PG_MAJOR}/lib/libpgrouting*.so \
+		| awk '{print $3}' | grep '^/' | sort | uniq > /tmp/all-deps.out && \
+	# Extract all the libs that aren't already part of the base image
+	comm -13 /tmp/base-image-libs.out /tmp/all-deps.out > /tmp/libraries.out && \
+	while read -r lib; do \
+		resolved=$(readlink -f "$lib"); \
+		dir=$(dirname "$lib"); \
+		base=$(basename "$lib"); \
+		# Copy the real file
+		cp -a "$resolved" /system/; \
+		# Reconstruct all its symlinks
+		for file in "$dir"/"${base%.so*}.so"*; do \
+			[ -e "$file" ] || continue; \
+			# If it's a symlink and it resolves to the same real file, we reconstruct it
+			if [ -L "$file" ] && [ "$(readlink -f "$file")" = "$resolved" ]; then \
+				ln -sf "$(basename "$resolved")" "/system/$(basename "$file")"; \
+			fi; \
+		done; \
+	done < /tmp/libraries.out && \
+	# Get licenses
+	for lib in $(find /system -maxdepth 1 -type f -name '*.so*'); do \
+		# Get the name of the pkg that installed the library
+		pkg=$(dpkg -S "$(basename "$lib")" | grep -v "diversion by" | awk -F: '/:/{print $1; exit}'); \
+		[ -z "$pkg" ] && continue; \
+		mkdir -p "/licenses/$pkg" && cp -a "/usr/share/doc/$pkg/copyright" "/licenses/$pkg/copyright"; \
+	done
+
+
+FROM scratch
+ARG PG_MAJOR
+
+# Licenses
+COPY --from=builder /licenses /licenses/
+COPY --from=builder /usr/share/doc/postgresql-${PG_MAJOR}-pgrouting/copyright /licenses/postgresql-${PG_MAJOR}-pgrouting/
+
+# Libraries
+COPY --from=builder \
+	/usr/lib/postgresql/${PG_MAJOR}/lib/libpgrouting* \
+	/lib/
+
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/bitcode/ /lib/bitcode/
+
+# Share
+COPY --from=builder \
+	/usr/share/postgresql/${PG_MAJOR}/extension/pgrouting* \
+	/share/extension/
+
+# System libs
+COPY --from=builder /system /system/
+
+USER 65532:65532

--- a/pgrouting/Dockerfile
+++ b/pgrouting/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
 FROM $BASE AS builder
 

--- a/pgrouting/README.md
+++ b/pgrouting/README.md
@@ -1,0 +1,80 @@
+# pgRouting
+
+[pgRouting](https://pgrouting.org/) extends the [PostGIS](https://postgis.net/)/PostgreSQL geospatial database to provide geospatial routing and other network analysis functionality.
+
+This image provides a convenient way to deploy and manage `pgRouting` with [CloudNativePG](https://cloudnative-pg.io/).
+
+> [!NOTE]
+> `pgRouting` depends on `PostGIS`. When deploying `pgRouting`, you must also include the `postgis` extension image in your Cluster definition.
+
+## Usage
+
+### 1. Add the pgRouting and PostGIS extension images to your Cluster
+
+Define the `postgis` and `pgrouting` extensions under the `postgresql.extensions` section of your `Cluster` resource. For example:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pgrouting
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    extensions:
+    - name: postgis
+      image:
+        # renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3
+        reference: ghcr.io/cloudnative-pg/postgis-extension:3.6.4-18-trixie
+      ld_library_path:
+      - system
+      env:
+      - name: GDAL_DATA
+        value: ${image_root}/share/gdal
+      - name: PROJ_DATA
+        value: ${image_root}/share/proj
+    - name: pgrouting
+      image:
+        # renovate: suite=trixie-pgdg depName=postgresql-18-pgrouting
+        reference: ghcr.io/cloudnative-pg/pgrouting:4.0.1-18-trixie
+      ld_library_path:
+      - system
+```
+
+### 2. Enable the extension in a database
+
+You can install `pgrouting` in a specific database by creating or updating a `Database` resource. Note that `postgis` must be listed before `pgrouting`:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: cluster-pgrouting-app
+spec:
+  name: app
+  owner: app
+  cluster:
+    name: cluster-pgrouting
+  extensions:
+  - name: postgis
+    # renovate: suite=trixie-pgdg depName=postgresql-18-postgis-3 extractVersion=^(?<version>\d+\.\d+\.\d+)
+    version: '3.6.4'
+  - name: pgrouting
+    # renovate: suite=trixie-pgdg depName=postgresql-18-pgrouting extractVersion=^(?<version>\d+\.\d+\.\d+)
+    version: '4.0.1'
+```
+
+### 3. Verify installation
+
+Once the database is ready, connect to it with `psql` and run:
+
+```sql
+\dx
+```
+
+You should see `postgis` and `pgrouting` listed among the installed extensions.

--- a/pgrouting/README.md
+++ b/pgrouting/README.md
@@ -1,17 +1,24 @@
 # pgRouting
+<!--
+SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+SPDX-License-Identifier: Apache-2.0
+-->
 
-[pgRouting](https://pgrouting.org/) extends the [PostGIS](https://postgis.net/)/PostgreSQL geospatial database to provide geospatial routing and other network analysis functionality.
+[pgRouting](https://pgrouting.org/) extends the [PostGIS](https://postgis.net/)/PostgreSQL geospatial database to
+provide geospatial routing and other network analysis functionality.
 
 This image provides a convenient way to deploy and manage `pgRouting` with [CloudNativePG](https://cloudnative-pg.io/).
 
 > [!NOTE]
-> `pgRouting` depends on `PostGIS`. When deploying `pgRouting`, you must also include the `postgis` extension image in your Cluster definition.
+> `pgRouting` depends on `PostGIS`. When deploying `pgRouting`, you must also include the `postgis` extension image in
+> your Cluster definition.
 
 ## Usage
 
 ### 1. Add the pgRouting and PostGIS extension images to your Cluster
 
-Define the `postgis` and `pgrouting` extensions under the `postgresql.extensions` section of your `Cluster` resource. For example:
+Define the `postgis` and `pgrouting` extensions under the `postgresql.extensions` section of your `Cluster` resource.
+For example:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -42,13 +49,11 @@ spec:
       image:
         # renovate: suite=trixie-pgdg depName=postgresql-18-pgrouting
         reference: ghcr.io/cloudnative-pg/pgrouting:4.0.1-18-trixie
-      ld_library_path:
-      - system
 ```
 
 ### 2. Enable the extension in a database
 
-You can install `pgrouting` in a specific database by creating or updating a `Database` resource. Note that `postgis` must be listed before `pgrouting`:
+You can install `pgrouting` in a specific database by creating or updating a `Database` resource:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -78,3 +83,22 @@ Once the database is ready, connect to it with `psql` and run:
 ```
 
 You should see `postgis` and `pgrouting` listed among the installed extensions.
+
+---
+
+## Licenses and Copyright
+
+`pgRouting`:
+
+- **Copyright:** pgRouting Contributors
+- **License:** GNU General Public License v2.0 or later (`GPL-2.0-or-later`)
+
+All relevant license and copyright information for the `pgrouting` extension
+and its dependencies are bundled within the image at:
+
+```text
+/licenses/
+```
+
+By using this image, you agree to comply with the terms of the licenses
+contained therein.

--- a/pgrouting/README.md
+++ b/pgrouting/README.md
@@ -4,21 +4,23 @@ SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-[pgRouting](https://pgrouting.org/) extends the [PostGIS](https://postgis.net/)/PostgreSQL geospatial database to
-provide geospatial routing and other network analysis functionality.
+[pgRouting](https://pgrouting.org/) extends the
+[PostGIS](https://postgis.net/)/PostgreSQL geospatial database to provide
+geospatial routing and other network analysis functionality.
 
-This image provides a convenient way to deploy and manage `pgRouting` with [CloudNativePG](https://cloudnative-pg.io/).
+This image provides a convenient way to deploy and manage `pgRouting` with
+[CloudNativePG](https://cloudnative-pg.io/).
 
 > [!NOTE]
-> `pgRouting` depends on `PostGIS`. When deploying `pgRouting`, you must also include the `postgis` extension image in
-> your Cluster definition.
+> `pgRouting` depends on `PostGIS`. When deploying `pgRouting`, you must also
+> include the `postgis` extension image in your Cluster definition.
 
 ## Usage
 
 ### 1. Add the pgRouting and PostGIS extension images to your Cluster
 
-Define the `postgis` and `pgrouting` extensions under the `postgresql.extensions` section of your `Cluster` resource.
-For example:
+Define the `postgis` and `pgrouting` extensions under the
+`postgresql.extensions` section of your `Cluster` resource. For example:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -53,7 +55,8 @@ spec:
 
 ### 2. Enable the extension in a database
 
-You can install `pgrouting` in a specific database by creating or updating a `Database` resource:
+You can install `pgrouting` in a specific database by creating or updating a
+`Database` resource:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1

--- a/pgrouting/metadata.hcl
+++ b/pgrouting/metadata.hcl
@@ -7,10 +7,10 @@ metadata = {
   postgresql_parameters    = {}
   extension_control_path   = []
   dynamic_library_path     = []
-  ld_library_path          = ["system"]
+  ld_library_path          = []
   bin_path                 = []
   env                      = {}
-  auto_update_os_libs      = true
+  auto_update_os_libs      = false
   required_extensions      = ["postgis"]
   create_extension         = true
 

--- a/pgrouting/metadata.hcl
+++ b/pgrouting/metadata.hcl
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
+# SPDX-License-Identifier: Apache-2.0
 metadata = {
   name                     = "pgrouting"
   sql_name                 = "pgrouting"

--- a/pgrouting/metadata.hcl
+++ b/pgrouting/metadata.hcl
@@ -1,0 +1,35 @@
+metadata = {
+  name                     = "pgrouting"
+  sql_name                 = "pgrouting"
+  image_name               = "pgrouting"
+  licenses                 = ["GPL-2.0-or-later"]
+  shared_preload_libraries = []
+  postgresql_parameters    = {}
+  extension_control_path   = []
+  dynamic_library_path     = []
+  ld_library_path          = ["system"]
+  bin_path                 = []
+  env                      = {}
+  auto_update_os_libs      = true
+  required_extensions      = ["postgis"]
+  create_extension         = true
+
+  versions = {
+    bookworm = {
+      "18" = {
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgrouting
+        package = "4.0.1-1.pgdg12+1"
+        // renovate: suite=bookworm-pgdg depName=postgresql-18-pgrouting extractVersion=^(?<version>\d+\.\d+\.\d+)
+        sql     = "4.0.1"
+      }
+    }
+    trixie = {
+      "18" = {
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgrouting
+        package = "4.0.1-1.pgdg13+1"
+        // renovate: suite=trixie-pgdg depName=postgresql-18-pgrouting extractVersion=^(?<version>\d+\.\d+\.\d+)
+        sql     = "4.0.1"
+      }
+    }
+  }
+}

--- a/pgrouting/test/chainsaw-test.yaml
+++ b/pgrouting/test/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: verify-pgrouting-extension
+spec:
+  timeouts:
+    apply: 5s
+    assert: 3m
+    delete: 30s
+  description: Verify pgrouting extension is properly installed
+  steps:
+  - name: Create a Cluster with the extension
+    try:
+    - apply:
+        file: cluster.yaml
+    - apply:
+        file: database.yaml
+    - assert:
+        file: cluster-assert.yaml
+    - assert:
+        file: database-assert.yaml
+
+  - name: Verify extension is installed
+    try:
+    - apply:
+        file: check-extension.yaml
+    - assert:
+        file: check-extension-assert.yaml

--- a/pgrouting/test/check-extension-assert.yaml
+++ b/pgrouting/test/check-extension-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: extension-installed
+status:
+  succeeded: 1

--- a/pgrouting/test/check-extension.yaml
+++ b/pgrouting/test/check-extension.yaml
@@ -26,3 +26,10 @@ spec:
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|")
            test "$(psql "$DB_URI" -tAc "SELECT EXISTS (SELECT FROM pg_catalog.pg_extension WHERE extname = 'postgis')" -q)" = "t"
            test "$(psql "$DB_URI" -tAc "SELECT EXISTS (SELECT FROM pg_catalog.pg_extension WHERE extname = 'pgrouting' AND extversion = '${EXT_VERSION}')" -q)" = "t"
+           psql "$DB_URI" -c "DROP TABLE IF EXISTS pgrouting_edges CASCADE;"
+           psql "$DB_URI" -c "CREATE TABLE pgrouting_edges (id BIGSERIAL PRIMARY KEY, source BIGINT, target BIGINT, cost DOUBLE PRECISION, reverse_cost DOUBLE PRECISION);"
+           psql "$DB_URI" -c "INSERT INTO pgrouting_edges (source, target, cost, reverse_cost) VALUES (1, 2, 1, 1), (2, 3, 1, 1), (3, 4, 1, 1), (1, 4, 5, 5);"
+           # The cheapest route from node 1 to node 4 is 1 -> 2 -> 3 -> 4 (cost 3),
+           # not the direct edge 1 -> 4 (cost 5).
+           test "$(psql "$DB_URI" -tAc "SELECT string_agg(node::text, ',' ORDER BY path_seq) FROM pgr_dijkstra('SELECT id, source, target, cost, reverse_cost FROM pgrouting_edges', 1, 4)" -q)" = "1,2,3,4"
+           test "$(psql "$DB_URI" -tAc "SELECT max(agg_cost) FROM pgr_dijkstra('SELECT id, source, target, cost, reverse_cost FROM pgrouting_edges', 1, 4)" -q)" = "3"

--- a/pgrouting/test/check-extension.yaml
+++ b/pgrouting/test/check-extension.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: extension-installed
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: data-test
+        env:
+          - name: PGSSLROOTCERT
+          - name: EXT_VERSION
+            value: ($values.version)
+          - name: DB_URI
+            valueFrom:
+              secretKeyRef:
+                name: (join('-', [$values.name, 'app']))
+                key: uri
+        # renovate: datasource=docker depName=alpine/psql versioning=docker
+        image: alpine/psql:18.4@sha256:b3e4fc061da067813ddc5a8844b1992a50d5f1dce72d46be8ee5d0b964a3e894
+        command: ['sh', '-c']
+        args:
+         - |
+           set -e
+           DB_URI=$(echo $DB_URI | sed "s|/\*|/|")
+           test "$(psql "$DB_URI" -tAc "SELECT EXISTS (SELECT FROM pg_catalog.pg_extension WHERE extname = 'postgis')" -q)" = "t"
+           test "$(psql "$DB_URI" -tAc "SELECT EXISTS (SELECT FROM pg_catalog.pg_extension WHERE extname = 'pgrouting' AND extversion = '${EXT_VERSION}')" -q)" = "t"

--- a/pgrouting/test/check-extension.yaml
+++ b/pgrouting/test/check-extension.yaml
@@ -9,7 +9,6 @@ spec:
       containers:
       - name: data-test
         env:
-          - name: PGSSLROOTCERT
           - name: EXT_VERSION
             value: ($values.version)
           - name: DB_URI

--- a/pgrouting/test/cluster-assert.yaml
+++ b/pgrouting/test/cluster-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ($values.name)
+status:
+  instances: 1
+  readyInstances: 1
+  phase: Cluster in healthy state

--- a/pgrouting/test/cluster.yaml
+++ b/pgrouting/test/cluster.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ($values.name)
+spec:
+  imageName: ($values.pg_image)
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    parameters: ($values.postgresql_parameters)
+    shared_preload_libraries: ($values.shared_preload_libraries)
+    extensions: ($values.extensions)

--- a/pgrouting/test/database-assert.yaml
+++ b/pgrouting/test/database-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: (join('-', [$values.name, 'app']))
+status: ($values.database_assert_status)

--- a/pgrouting/test/database.yaml
+++ b/pgrouting/test/database.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: (join('-', [$values.name, 'app']))
+spec:
+  name: app
+  owner: app
+  cluster:
+    name: ($values.name)
+  extensions: ($values.database_config.extensions_spec)


### PR DESCRIPTION
## Description

Add pgRouting extension container image for CloudNativePG targeting PostgreSQL 18 across Debian bookworm and trixie distributions, as discussed in https://github.com/cloudnative-pg/postgis-containers/pull/134

## Type of change

<!-- Tick the box that applies (put an "x" between the brackets, no spaces). -->

- [ ] Update to an existing extension (version bump, fix)
- [ ] Shared build infrastructure / tooling change
- [ ] Documentation only
- [x] Other (please describe above)

<!-- If this fixes an open issue, reference it here, for example: Closes #123 -->


---

## Contributor checklist

- [x] My commits are signed off for [DCO](https://developercertificate.org/)
      compliance (`git commit -s`).
- [x] This PR targets the `main` branch of the upstream repository.
- [x] `task checks:all` passes locally.
- [x] For changes affecting one or more extensions, the relevant build and E2E
      tests pass (e.g. `task bake TARGET=<ext>`, `task e2e:test:full TARGET=<ext>`).
- [x] Any `// renovate:` comments touched in `metadata.hcl` / `README.md` remain
      intact (`suite=`, `depName=`, `extractVersion=`).
- [x] Documentation (`README.md`, `BUILD.md`, ...) updated where relevant.

---

## Maintainer review checklist

<!-- For maintainers only. -->

- [x] CI is green for all affected targets / shared changes.
- [x] DCO check passes.
- [x] Change reviewed for correctness and scope; no unintended targets rebuilt.
- [x] `// renovate:` annotations preserved so automated version tracking keeps
      working.
- [x] If shared infrastructure changed, the `_shared` filter in
      `.github/workflows/bake.yml` was updated when all extensions must rebuild.
- [x] PR targets `main` and is ready to merge.

Closes #300 