### PR TITLE
chore: add SECURITY-INSIGHTS.yml

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_extension.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_extension.md
@@ -52,6 +52,9 @@ Closes #<!-- proposal issue id -->
 - [ ] An entry for the new extension folder was added to
       [`CODEOWNERS`](https://github.com/cloudnative-pg/postgres-extensions-containers/blob/main/CODEOWNERS)
       with the component owner's GitHub handle(s).
+- [ ] A `distribution-points` entry for the new image was added under
+      `repository.release` in
+      [`SECURITY-INSIGHTS.yml`](https://github.com/cloudnative-pg/postgres-extensions-containers/blob/main/SECURITY-INSIGHTS.yml).
 - [ ] I confirm my commitment to maintain this extension on behalf of the
       CloudNativePG community.
 
@@ -84,4 +87,6 @@ Closes #<!-- proposal issue id -->
       when `create_extension = true`) are valid.
 - [ ] `CODEOWNERS` entry is present and the component owner(s) accept the
       long-term maintenance commitment.
+- [ ] `SECURITY-INSIGHTS.yml` has a matching `distribution-points` entry for
+      the new image.
 - [ ] PR targets `main` and is ready to merge.

--- a/CONTRIBUTING_NEW_EXTENSION.md
+++ b/CONTRIBUTING_NEW_EXTENSION.md
@@ -301,6 +301,10 @@ Submission Requirements:
 - **CODEOWNERS**: The PR must add an entry to the [`CODEOWNERS`](./CODEOWNERS)
   file listing the GitHub handles of the component owner(s) for the new
   extension folder.
+- **SECURITY-INSIGHTS.yml**: The PR must add a `distribution-points` entry for
+  the new image under `repository.release` in
+  [`SECURITY-INSIGHTS.yml`](./SECURITY-INSIGHTS.yml), pointing to its GitHub
+  Packages page (using the `image_name` from `metadata.hcl`).
 
 > [!IMPORTANT]
 > When opening the Pull Request, use the **new extension** template, which

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -92,15 +92,33 @@ repository:
           adhoc: false
           ci: true
           release: true
+      - name: CodeQL
+        type: SAST
+        rulesets: ["default"]
+        results: {}
+        comment: GitHub's default CodeQL setup; analyzes Go and GitHub Actions workflow code on pull requests and pushes to main.
+        integration:
+          adhoc: false
+          ci: true
+          release: false
       - name: GitHub Code Scanning
         type: SAST
         rulesets: ["default"]
         results: {}
-        comment: GitHub's default CodeQL setup, enabled at the repo-settings level.
+        comment: Ingests SARIF results from Snyk for integrated GitHub security alerts.
         integration:
           adhoc: false
-          ci: false
-          release: false
+          ci: true
+          release: true
+      - name: Dockle
+        type: container
+        rulesets: ["default"]
+        results: {}
+        comment: Container image linter enforcing CIS Docker Benchmark best practices; fails the build on any warning.
+        integration:
+          adhoc: false
+          ci: true
+          release: true
 
     assessments:
       self:

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,107 @@
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-08-04'
+  last-reviewed: '2026-08-04'
+  url: https://raw.githubusercontent.com/cloudnative-pg/postgres-extensions-containers/main/SECURITY-INSIGHTS.yml
+  # reference the main SECURITY-INSIGHTS file from CNPG repo
+  project-si-source: https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/SECURITY-INSIGHTS.yml
+
+repository:
+  url: https://github.com/cloudnative-pg/postgres-extensions-containers
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name: Gabriele Bartolini
+      email: gabriele.bartolini@enterprisedb.com
+      primary: true
+    - name: Leonardo Cecchi
+      email: leonardo.cecchi@enterprisedb.com
+      primary: false
+    - name: Marco Nenciarini
+      email: marco.nenciarini@enterprisedb.com
+      primary: false
+    - name: Francesco Canovai
+      email: francesco.canovai@enterprisedb.com
+      primary: false
+    - name: Armando Ruocco
+      email: armando.ruocco@enterprisedb.com
+      primary: false
+    - name: Niccolò Fei
+      email: niccolo.fei@enterprisedb.com
+      primary: false
+    - name: Gabriele Fedi
+      email: gabriele.fedi@enterprisedb.com
+      primary: false
+  license:
+    url: https://www.apache.org/licenses/LICENSE-2.0
+    expression: Apache-2.0
+
+  release:
+    automated-pipeline: true
+    distribution-points:
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/pgvector
+        comment: GitHub packages for the pgvector extension image
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/postgis-extension
+        comment: GitHub packages for the PostGIS extension image
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/pgaudit
+        comment: GitHub packages for the pgaudit extension image
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/pg-ivm
+        comment: GitHub packages for the pg_ivm extension image
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/pg-crash
+        comment: GitHub packages for the pg_crash extension image
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/timescaledb-oss
+        comment: GitHub packages for the TimescaleDB (OSS) extension image
+      - uri: https://github.com/cloudnative-pg/postgres-extensions-containers/pkgs/container/wal2json
+        comment: GitHub packages for the wal2json extension image
+
+  security:
+    tools:
+      - name: Dependabot
+        type: SCA
+        rulesets: ["default"]
+        results: {}
+        integration:
+          adhoc: true
+          ci: false
+          release: false
+      - name: Renovate
+        type: SCA
+        rulesets: ["default"]
+        results: {}
+        integration:
+          adhoc: true
+          ci: true
+          release: false
+      - name: Snyk
+        type: container
+        rulesets: ["default"]
+        results: {}
+        comment: Scans container images for known vulnerabilities.
+        integration:
+          adhoc: false
+          ci: true
+          release: true
+      - name: Cosign
+        type: container
+        rulesets: ["default"]
+        results: {}
+        comment: Used to cryptographically sign container images.
+        integration:
+          adhoc: false
+          ci: true
+          release: true
+      - name: GitHub Code Scanning
+        type: SAST
+        rulesets: ["default"]
+        results: {}
+        comment: GitHub's default CodeQL setup, enabled at the repo-settings level.
+        integration:
+          adhoc: false
+          ci: false
+          release: false
+
+    assessments:
+      self:
+        comment: Refer to the main project.


### PR DESCRIPTION
Adds a `SECURITY-INSIGHTS.yml` for this repo, modeled on [cloudnative-pg/postgres-containers's file](https://github.com/cloudnative-pg/postgres-containers/blob/main/SECURITY-INSIGHTS.yml): repository-scoped, pointing back to the main project's file via `header.project-si-source`, with this repo's own core-team (matching `cloudnative-pg/cnpg-infra`'s `repo-tiers.yaml` owners), license, release distribution points, and security tooling — verified against this repo's actual CI workflows and repo settings rather than copied from another repo.

Part of extending `SECURITY-INSIGHTS.yml` coverage to every Class A repo (see `cnpg-infra/repo-tiers.yaml`), starting with this one.

Assisted-by: Claude