### PR TITLE
ci: add workflow to cleanup -testing operand image

### DIFF
--- a/.github/workflows/registry-clean.yml
+++ b/.github/workflows/registry-clean.yml
@@ -7,20 +7,50 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-env:
-  IMAGE_NAME: "postgis-extension-testing, pgvector-testing, pgaudit-testing, pg-crash-testing, timescaledb-oss-testing, wal2json-testing, pg-ivm-testing, pgrouting-testing"
+permissions: {}
 
 jobs:
   clean-ghcr:
     name: delete old testing container images
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - name: Delete '-testing' operand images in ${{ env.IMAGE_NAME }}
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Fetch valid targets
+        id: get-targets
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
+        env:
+          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+          DAGGER_VERSION: 0.21.8
+        with:
+          version: ${{ env.DAGGER_VERSION }}
+          verb: call
+          module: ./dagger/maintenance/
+          args: get-targets
+
+      - name: Compute image-names list
+        id: image-names
+        env:
+          VALID_TARGETS: ${{ steps.get-targets.outputs.output }}
+        run: |
+          image_names=()
+          for extension in $(jq -r '.[]' <<< "$VALID_TARGETS"); do
+            image_name=$(sed -n 's/^\s*image_name\s*=\s*"\(.*\)"$/\1/p' "${extension}/metadata.hcl")
+            image_names+=("${image_name}-testing")
+          done
+          printf -v joined '%s, ' "${image_names[@]}"
+          echo "value=${joined%, }" >> "$GITHUB_OUTPUT"
+
+      - name: Delete '-testing' operand images
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
-          image-names: ${{ env.IMAGE_NAME }}
+          image-names: ${{ steps.image-names.outputs.value }}
           cut-off: 1w
           keep-n-most-recent: 1
           account: ${{ github.repository_owner }}

--- a/.github/workflows/registry-clean.yml
+++ b/.github/workflows/registry-clean.yml
@@ -1,0 +1,27 @@
+# This workflow runs daily to clean up the `*-testing` images older than the
+# cut-off period specified in `snok/container-retention-policy`
+name: clean-testing-package
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  IMAGE_NAME: "postgis-extension-testing, pgvector-testing, pgaudit-testing, pg-crash-testing, timescaledb-oss-testing, wal2json-testing, pg-ivm-testing, pgrouting-testing"
+
+jobs:
+  clean-ghcr:
+    name: delete old testing container images
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete '-testing' operand images in ${{ env.IMAGE_NAME }}
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
+        with:
+          image-names: ${{ env.IMAGE_NAME }}
+          cut-off: 1w
+          keep-n-most-recent: 1
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Discovers image names per extension via the dagger maintenance
module, since this repo bakes one image per extension.