### PR TITLE
fix: add `wal2json` to `output_plugin_libraries` for PG 18.6+

### DIFF
--- a/wal2json/README.md
+++ b/wal2json/README.md
@@ -24,7 +24,12 @@ This image provides a convenient way to deploy and manage `wal2json` with
 
 Define the `wal2json` extension under the `postgresql.extensions` section of
 your `Cluster` resource. Logical decoding requires `wal_level` to be set to
-`logical`:
+`logical`. On PostgreSQL 18.6+, the server also restricts which libraries may
+be used as logical decoding output plugins via the `output_plugin_libraries`
+allow-list ([CVE-2026-6471](https://www.postgresql.org/support/security/CVE-2026-6471/));
+`wal2json` must be added to it explicitly, alongside the built-in defaults
+(`pgoutput`, `test_decoding`), since setting this parameter replaces
+PostgreSQL's default rather than extending it:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -41,6 +46,7 @@ spec:
   postgresql:
     parameters:
       wal_level: logical
+      output_plugin_libraries: "pgoutput, test_decoding, wal2json"
     extensions:
     - name: wal2json
       image:
@@ -52,6 +58,13 @@ spec:
 > Unlike most extensions, `wal2json` is a logical decoding output plugin and
 > does not require a `Database` resource with `CREATE EXTENSION`. The plugin
 > is referenced directly when a logical replication slot is created.
+
+> [!IMPORTANT]
+> `output_plugin_libraries` does not exist before PostgreSQL 18.6. Setting it
+> on an older 18.x image is **not** harmless: PostgreSQL treats the unknown
+> parameter as a configuration error and the instance **fails to start**
+> (`FATAL: configuration file "postgresql.conf" contains errors`). Only set
+> this parameter if your image is pinned to PostgreSQL 18.6 or later.
 
 ### 2. Create a logical replication slot using `wal2json`
 

--- a/wal2json/metadata.hcl
+++ b/wal2json/metadata.hcl
@@ -6,7 +6,13 @@ metadata = {
   image_name               = "wal2json"
   licenses                 = ["BSD-3-Clause"]
   shared_preload_libraries = []
-  postgresql_parameters    = {}
+  # PostgreSQL 18.6+ restricts logical decoding output plugins to an
+  # allow-list (CVE-2026-6471). Without this, pg_create_logical_replication_slot(...,
+  # 'wal2json') fails with "library wal2json may not be used as an output
+  # plugin". pgoutput/test_decoding are the built-in defaults; they must be
+  # re-listed here because setting this parameter replaces PostgreSQL's
+  # default rather than extending it.
+  postgresql_parameters    = { output_plugin_libraries = "pgoutput, test_decoding, wal2json" }
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = []

--- a/wal2json/metadata.hcl
+++ b/wal2json/metadata.hcl
@@ -6,13 +6,9 @@ metadata = {
   image_name               = "wal2json"
   licenses                 = ["BSD-3-Clause"]
   shared_preload_libraries = []
-  # PostgreSQL 18.6+ restricts logical decoding output plugins to an
-  # allow-list (CVE-2026-6471). Without this, pg_create_logical_replication_slot(...,
-  # 'wal2json') fails with "library wal2json may not be used as an output
-  # plugin". pgoutput/test_decoding are the built-in defaults; they must be
-  # re-listed here because setting this parameter replaces PostgreSQL's
-  # default rather than extending it.
-  postgresql_parameters    = { output_plugin_libraries = "pgoutput, test_decoding, wal2json" }
+  postgresql_parameters    = {
+    output_plugin_libraries = "pgoutput, test_decoding, wal2json"
+  }
   extension_control_path   = []
   dynamic_library_path     = []
   ld_library_path          = []


### PR DESCRIPTION
PostgreSQL 18.6 introduced `output_plugin_libraries`, an allow-list restricting which libraries may be used as logical decoding output plugins (`CVE-2026-6471`). Without `wal2json` explicitly listed, `pg_create_logical_replication_slot(..., 'wal2json')` fails with:

    ERROR: library "wal2json" may not be used as an output plugin

This is what broke the `wal2json` smoke test once the floating `postgresql:18-minimal-*` base images moved from 18.4 to 18.6: the Job that exercises dlopen of `wal2json.so` via slot creation kept failing and retrying (`CrashLoopBackOff`) until the chainsaw assert timeout, which is why CI showed an empty Job status rather than a clear error.

Set `postgresql_parameters.output_plugin_libraries` in `metadata.hcl` so the extension's own test Cluster allow-lists `wal2json` (re-listing the built-in pgoutput/test_decoding defaults too, since setting this GUC replaces PostgreSQL's default rather than extending it). Update the README's example Cluster manifest accordingly, with a note that this parameter does not exist before 18.6 and setting it there is fatal (verified: postmaster refuses to start).

Closes #318
