### PR TITLE
fix: support base-image extension dependencies

### DIFF
--- a/dagger/maintenance/main.go
+++ b/dagger/maintenance/main.go
@@ -202,9 +202,12 @@ func (m *Maintenance) GenerateTestingValues(
 		return nil, err
 	}
 
-	extensions := make([]*ExtensionConfiguration, len(extensionInfos))
-	for i, info := range extensionInfos {
-		extensions[i] = info.Configuration
+	extensions := make([]*ExtensionConfiguration, 0, len(extensionInfos))
+	for _, info := range extensionInfos {
+		if info.Configuration == nil {
+			continue
+		}
+		extensions = append(extensions, info.Configuration)
 	}
 
 	databaseConfig := generateDatabaseConfig(extensionInfos)

--- a/dagger/maintenance/testingvalues.go
+++ b/dagger/maintenance/testingvalues.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"dagger/maintenance/internal/dagger"
 )
@@ -37,6 +38,8 @@ type testingExtensionInfo struct {
 	CreateExtension bool
 }
 
+const baseImageDependencyPrefix = "base-image:"
+
 type imageLocator struct {
 	ExtensionImage string
 	PgMajor        int
@@ -64,7 +67,19 @@ func generateTestingValuesExtensions(
 		CreateExtension: metadata.CreateExtension,
 	})
 
-	for _, dep := range metadata.RequiredExtensions {
+	for _, requiredDependency := range metadata.RequiredExtensions {
+		dep, isBaseImageDependency, err := parseRequiredDependency(requiredDependency)
+		if err != nil {
+			return nil, err
+		}
+		if isBaseImageDependency {
+			out = append(out, &testingExtensionInfo{
+				SQLName:         dep,
+				CreateExtension: true,
+			})
+			continue
+		}
+
 		depExists, err := source.Exists(ctx, dep)
 		if err != nil {
 			return nil, err
@@ -106,6 +121,19 @@ func generateTestingValuesExtensions(
 	}
 
 	return out, nil
+}
+
+func parseRequiredDependency(dependency string) (string, bool, error) {
+	if !strings.HasPrefix(dependency, baseImageDependencyPrefix) {
+		return dependency, false, nil
+	}
+
+	name := strings.TrimPrefix(dependency, baseImageDependencyPrefix)
+	if name == "" {
+		return "", false, fmt.Errorf("base-image dependency %q has no extension name", dependency)
+	}
+
+	return name, true, nil
 }
 
 func generateExtensionConfiguration(metadata *extensionMetadata, extensionImage string) (*ExtensionConfiguration, error) {

--- a/templates/metadata.hcl.tmpl
+++ b/templates/metadata.hcl.tmpl
@@ -98,8 +98,10 @@ metadata = {
   auto_update_os_libs      = false
 
   # TODO: Remove this comment block after customizing the file.
-  # `required_extensions`: must contain the name(s) of the sibling
-  # folders in this repository that contain a required extension.
+  # `required_extensions`: names of required extensions. By default each name
+  # must identify a sibling folder in this repository. Prefix dependencies
+  # provided by the PostgreSQL base image with `base-image:` (for example,
+  # `base-image:pg_stat_statements`).
   required_extensions      = []
 
   # TODO: Remove this comment block after customizing the file.


### PR DESCRIPTION
Current code doesn't work if an extension dependency is in the base image.  I ran into this while working on `pg-stat-kcache` and `pgsentinel` which both depend on `pg_stat_statements`.

We need to support both models - some dependencies are not in the base image (eg. `pgrouting` or `mobilitydb`)

## Proposed behavior

Base-image dependencies use an explicit prefix in the existing
`required_extensions` field:

```hcl
required_extensions = ["base-image:pg_stat_statements"]
```

For such a dependency:

1. It is omitted from the generated extension image list.
2. It remains in the generated database extension specification so the test database installs it from the base image.

Unprefixed dependencies retain the current local-repository behavior, and a missing unprefixed dependency remains an error.

## Validation

- `DAGGER_SESSION_PORT=1 DAGGER_SESSION_TOKEN=test go test ./...`
- Dagger target discovery across all existing metadata files
- Repository `.github/workflows/test.yml` unit-test job via `act`
- Docker Buildx `--check` for `pg-crash`, `pg-ivm`, `pgaudit`, `pgrouting`, `pgvector`, `postgis`, `timescaledb-oss`, and `wal2json`
